### PR TITLE
Remove std.intrinsic

### DIFF
--- a/win32/dfl/socket.d
+++ b/win32/dfl/socket.d
@@ -86,7 +86,7 @@ private
 	}
 	else
 	{
-		private import std.socket, std.intrinsic;
+		private import std.socket, core.bitop;
 		private import std.c.windows.winsock;
 		
 		alias InternetHost DInternetHost;


### PR DESCRIPTION
std.intrinsicはdeprecatedとマークされて、core.bitopに置き換わりました。
いちいちコンパイラさんに怒られるのがウザかったので…
en: s/std.intrinsic/core.bitop/ for mark of deprecated.
