### PR TITLE
Update for 2.054 compiler

### DIFF
--- a/win32/dfl/button.d
+++ b/win32/dfl/button.d
@@ -379,13 +379,10 @@ class Button: ButtonBase, IButtonControl // docmain
 	
 	
 	override void text(Dstring txt) // setter
-	in
 	{
-		if(txt.length)
+		if(txt.length) {
 			assert(!this.image, "Button image with text not supported");
-	}
-	body
-	{
+		}
 		super.text = txt;
 	}
 	

--- a/win32/dfl/internal/dlib.d
+++ b/win32/dfl/internal/dlib.d
@@ -469,7 +469,7 @@ else // Phobos
 		}
 	}
 	
-	alias std.string.find charFindInString;
+	alias std.algorithm.find charFindInString;
 	
 	alias std.string.toStringz stringToStringz;
 	
@@ -567,9 +567,9 @@ else // Phobos
 	}
 	
 	
-	private import std.ctype;
+	private import std.ascii;
 	
-	alias std.ctype.isxdigit charIsHexDigit;
+	alias std.ascii.isHexDigit charIsHexDigit;
 	
 	
 	private import std.stream;

--- a/win32/dfl/tabcontrol.d
+++ b/win32/dfl/tabcontrol.d
@@ -56,6 +56,10 @@ class TabPage: Panel
 		return text == getObjectString(o);
 	}
 	
+	override Dequ opEquals(Control o)
+	{
+		return super.opEquals(o);
+	}
 	
 	Dequ opEquals(Dstring val)
 	{
@@ -68,6 +72,10 @@ class TabPage: Panel
 		return stringICmp(text, getObjectString(o));
 	}
 	
+	override int opCmp(Control o)
+	{
+		return super.opCmp(o);
+	}
 	
 	int opCmp(Dstring val)
 	{


### PR DESCRIPTION
Removed improper 'in' contract.
Changed std.string.find alias to algorithm.
Have TabControl override all opEquals and opCmp of Control
