### PR TITLE
This change supports warning and deprecated codes.

### DIFF
--- a/win32/dfl/application.d
+++ b/win32/dfl/application.d
@@ -474,13 +474,11 @@ final class Application // docmain
 		{
 			//throw new DflException("Cannot have more than one message loop per thread");
 			assert(0, "Cannot have more than one message loop per thread");
-			return;
 		}
 		
 		if(threadFlags & TF.QUIT)
 		{
 			assert(0, "The application is shutting down");
-			return;
 		}
 		
 		version(CUSTOM_MSG_HOOK)
@@ -1258,7 +1256,6 @@ final class Application // docmain
 			if(messageLoop)
 			{
 				assert(0, "setCompat"); // Called too late, must enable compatibility sooner.
-				return;
 			}
 			
 			_compat |= dflcompat;
@@ -1719,9 +1716,8 @@ extern(Windows) LRESULT dflWndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lp
 							Application.onThreadException(e2);
 						}
 					}
-					return LRESULT_DFL_INVOKE;
 				}
-				break;
+				return LRESULT_DFL_INVOKE;
 			
 			case WPARAM_DFL_INVOKE_SIMPLE:
 				{
@@ -1743,9 +1739,8 @@ extern(Windows) LRESULT dflWndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lp
 							Application.onThreadException(e2);
 						}
 					}
-					return LRESULT_DFL_INVOKE;
 				}
-				break;
+				return LRESULT_DFL_INVOKE;
 			
 			case WPARAM_DFL_DELAY_INVOKE:
 				try

--- a/win32/dfl/button.d
+++ b/win32/dfl/button.d
@@ -240,7 +240,7 @@ abstract class ButtonBase: ControlSuperClass // docmain
 	
 	
 	///
-	Size defaultSize() // getter
+	override Size defaultSize() // getter
 	{
 		return Size(75, 23);
 	}

--- a/win32/dfl/combobox.d
+++ b/win32/dfl/combobox.d
@@ -138,7 +138,7 @@ class ComboBox: ListControl // docmain
 	
 	
 	///
-	void selectedIndex(int idx)
+	override void selectedIndex(int idx)
 	{
 		if(isHandleCreated)
 		{
@@ -147,7 +147,7 @@ class ComboBox: ListControl // docmain
 	}
 	
 	/// ditto
-	int selectedIndex()
+	override int selectedIndex()
 	{
 		if(isHandleCreated)
 		{

--- a/win32/dfl/control.d
+++ b/win32/dfl/control.d
@@ -703,7 +703,6 @@ class Control: DObject, IWindow // docmain
 				}
 				// Index out of bounds, bad things happen.
 				assert(0);
-				return null;
 			}
 			else
 			{
@@ -2370,7 +2369,6 @@ class Control: DObject, IWindow // docmain
 					goto case RightToLeft.YES;
 				}
 				goto case RightToLeft.NO;
-				break;
 			
 			case RightToLeft.YES:
 				_exStyle(_exStyle() | WS_EX_RTLREADING);
@@ -5376,9 +5374,8 @@ class Control: DObject, IWindow // docmain
 					if(!(GetKeyState(VK_MENU) & 0x8000))
 						msg.result |= DLGC_WANTCHARS;
 					
-					return;
 				}
-				break;
+				return;
 			
 			case WM_CLOSE:
 				/+{

--- a/win32/dfl/drawing.d
+++ b/win32/dfl/drawing.d
@@ -2677,11 +2677,7 @@ class Graphics // docmain
 	// to the previous point.
 	final void drawLines(Pen pen, Point[] points)
 	{
-		if(points.length < 2)
-		{
-			assert(0); // Not enough line points.
-			return;
-		}
+		assert(points.length < 2, "Not enough line points.");
 		
 		HPEN prevPen;
 		int i;
@@ -3290,7 +3286,7 @@ class Icon: Image // docmain
 	}
 	
 	
-	int _imgtype(HGDIOBJ* ph) // internal
+	override int _imgtype(HGDIOBJ* ph) // internal
 	{
 		if(ph)
 			*ph = cast(HGDIOBJ)hi;

--- a/win32/dfl/filedialog.d
+++ b/win32/dfl/filedialog.d
@@ -445,7 +445,6 @@ abstract class FileDialog: CommonDialog // docmain
 	override bool runDialog(HWND owner)
 	{
 		assert(0);
-		return false;
 	}
 	
 	

--- a/win32/dfl/form.d
+++ b/win32/dfl/form.d
@@ -337,7 +337,8 @@ class Form: ContainerControl, IDialogResult // docmain
 							cp.y = area.bottom - cp.height;
 						break;
 					}
-					// No parent so use the screen.
+					break;
+				
 				case FormStartPosition.CENTER_SCREEN:
 					{
 						// TODO: map to client coords if MDI child.
@@ -355,6 +356,8 @@ class Form: ContainerControl, IDialogResult // docmain
 					cp.width = CW_USEDEFAULT;
 					cp.height = CW_USEDEFAULT;
 					//break; // DEFAULT_BOUNDS assumes default location.
+					goto case FormStartPosition.DEFAULT_LOCATION;
+				
 				case FormStartPosition.DEFAULT_LOCATION:
 					// WM_CREATE fixes these.
 					cp.x = CW_USEDEFAULT;
@@ -1092,13 +1095,14 @@ class Form: ContainerControl, IDialogResult // docmain
 		{
 			version(NO_MDI)
 			{
+				return null;
 			}
 			else
 			{
 				//if(isMdiChild)
 					return wmdiparent;
+				//return null;
 			}
-			return null;
 		}
 	}
 	
@@ -2060,7 +2064,10 @@ class Form: ContainerControl, IDialogResult // docmain
 				{
 					throw new DflException("Invalid dialog owner");
 				}
-				goto no_show;
+				else
+				{
+					goto no_show;
+				}
 			}
 			
 			//owner = null;
@@ -2550,7 +2557,7 @@ class Form: ContainerControl, IDialogResult // docmain
 	}
 	
 	
-	/+ package +/ void _destroying() // package
+	/+ package +/ override void _destroying() // package
 	{
 		_removeFromOldOwner();
 		//wowner = null;
@@ -2572,7 +2579,7 @@ class Form: ContainerControl, IDialogResult // docmain
 	}
 	
 	
-	/+ package +/ /+ protected +/ int _rtype() // package
+	/+ package +/ /+ protected +/ override int _rtype() // package
 	{
 		return isMdiChild ? 2 : 0;
 	}
@@ -3107,8 +3114,7 @@ class Form: ContainerControl, IDialogResult // docmain
 								}
 								return false;
 							
-							case Keys.UP, Keys.DOWN:
-							case Keys.RIGHT, Keys.LEFT:
+							case Keys.UP, Keys.DOWN, Keys.RIGHT, Keys.LEFT:
 								//if(dfl.internal.utf.isDialogMessage(form.handle, &m._winMsg)) // Stopped working after removing controlparent.
 								//	return true; // Prevent.
 								{
@@ -3171,9 +3177,8 @@ class Form: ContainerControl, IDialogResult // docmain
 											_dlgselnext(form, m.hWnd, true);
 										}
 									}
-									return true; // Prevent.
 								}
-								break;
+								return true; // Prevent.
 							
 							default: ;
 						}

--- a/win32/dfl/groupbox.d
+++ b/win32/dfl/groupbox.d
@@ -38,7 +38,7 @@ class GroupBox: ControlSuperClass // docmain
 	
 	version(DFL_NO_DRAG_DROP) {} else
 	{
-		void allowDrop(bool dyes) // setter
+		override void allowDrop(bool dyes) // setter
 		{
 			//if(dyes)
 			//	throw new DflException("Cannot drop on a group box");
@@ -69,7 +69,7 @@ class GroupBox: ControlSuperClass // docmain
 	}
 	
 	
-	protected void onFontChanged(EventArgs ea)
+	protected override void onFontChanged(EventArgs ea)
 	{
 		_dispChanged();
 		
@@ -77,7 +77,7 @@ class GroupBox: ControlSuperClass // docmain
 	}
 	
 	
-	protected void onHandleCreated(EventArgs ea)
+	protected override void onHandleCreated(EventArgs ea)
 	{
 		super.onHandleCreated(ea);
 		

--- a/win32/dfl/internal/dlib.d
+++ b/win32/dfl/internal/dlib.d
@@ -483,11 +483,11 @@ else // Phobos
 	
 	private import std.path;
 	
-	alias std.path.getDirName pathGetDirName;
+	alias std.path.dirName pathGetDirName;
 	
 	alias std.path.linesep nativeLineSeparatorString;
 	
-	alias std.path.join pathJoin;
+	alias std.path.buildPath pathJoin;
 	
 	alias std.path.pathsep nativePathSeparatorString;
 	
@@ -533,7 +533,7 @@ else // Phobos
 	
 	alias std.utf.toUTF16 utf8stringtoUtf16string;
 	
-	alias std.utf.toUTF16z utf8stringToUtf16stringz;
+	alias std.utf.toUTFz!(typeof(Dwstring.init.ptr), Dstring) utf8stringToUtf16stringz;
 	
 	alias std.utf.toUTF8 utf32stringtoUtf8string;
 	

--- a/win32/dfl/internal/utf.d
+++ b/win32/dfl/internal/utf.d
@@ -2031,7 +2031,6 @@ BOOL _setMenuItemInfoW(HMENU hMenu, UINT uItem, BOOL fByPosition, LPMENUITEMINFO
 	else
 	{
 		assert(0);
-		return FALSE;
 	}
 }
 
@@ -2062,7 +2061,6 @@ BOOL _insertMenuItemW(HMENU hMenu, UINT uItem, BOOL fByPosition, LPMENUITEMINFOW
 	else
 	{
 		assert(0);
-		return FALSE;
 	}
 }
 

--- a/win32/dfl/listbox.d
+++ b/win32/dfl/listbox.d
@@ -148,7 +148,6 @@ class ListBox: ListControl // docmain
 			
 			// If it's not found it's out of bounds and bad things happen.
 			assert(0);
-			return -1;
 		}
 		
 		
@@ -245,7 +244,6 @@ class ListBox: ListControl // docmain
 			
 			// If it's not found it's out of bounds and bad things happen.
 			assert(0);
-			return null;
 		}
 		
 		
@@ -1402,11 +1400,9 @@ class ListBox: ListControl // docmain
 				msg.result = LB_ERR;
 				return;
 			
-			default:
-				super.wndProc(msg);
-				return;
+			default: ;
 		}
-		prevWndProc(msg);
+		super.wndProc(msg);
 	}
 	
 	

--- a/win32/dfl/listview.d
+++ b/win32/dfl/listview.d
@@ -999,7 +999,6 @@ class ListView: ControlSuperClass // docmain
 			
 			// If it's not found it's out of bounds and bad things happen.
 			assert(0);
-			return -1;
 		}
 		
 		
@@ -1088,7 +1087,6 @@ class ListView: ControlSuperClass // docmain
 			
 			// If it's not found it's out of bounds and bad things happen.
 			assert(0);
-			return null;
 		}
 		
 		
@@ -1175,7 +1173,6 @@ class ListView: ControlSuperClass // docmain
 			
 			// If it's not found it's out of bounds and bad things happen.
 			assert(0);
-			return -1;
 		}
 		
 		
@@ -1571,7 +1568,6 @@ class ListView: ControlSuperClass // docmain
 			return item;
 		}
 		assert(0);
-		return null;
 	}
 	
 	

--- a/win32/dfl/registry.d
+++ b/win32/dfl/registry.d
@@ -127,7 +127,7 @@ private const uint MAX_REG_BUFFER = 256;
 abstract class RegistryValue
 {
 	DWORD valueType(); // getter
-	Dstring toString();
+	override Dstring toString();
 	/+ package +/ protected LONG save(HKEY hkey, Dstring name); // package
 	package final RegistryValue _reg() { return this; }
 }
@@ -857,6 +857,7 @@ class RegistryKey // docmain
 			case ERROR_FILE_NOT_FOUND:
 				if(!throwIfMissing)
 					break;
+				goto default;
 			default:
 				throw new DflRegistryException("Unable to delete registry value", rr);
 		}

--- a/win32/dfl/richtextbox.d
+++ b/win32/dfl/richtextbox.d
@@ -674,18 +674,21 @@ class RichTextBox: TextBoxBase // docmain
 		{
 			case RichTextBoxScrollBars.FORCED_BOTH:
 				st |= ES_DISABLENOSCROLL;
+				goto case RichTextBoxScrollBars.BOTH;
 			case RichTextBoxScrollBars.BOTH:
 				st |= WS_HSCROLL | WS_VSCROLL | ES_AUTOHSCROLL | ES_AUTOVSCROLL;
 				break;
 			
 			case RichTextBoxScrollBars.FORCED_HORIZONTAL:
 				st |= ES_DISABLENOSCROLL;
+				goto case RichTextBoxScrollBars.HORIZONTAL;
 			case RichTextBoxScrollBars.HORIZONTAL:
 				st |= WS_HSCROLL | ES_AUTOHSCROLL;
 				break;
 			
 			case RichTextBoxScrollBars.FORCED_VERTICAL:
 				st |= ES_DISABLENOSCROLL;
+				goto case RichTextBoxScrollBars.VERTICAL;
 			case RichTextBoxScrollBars.VERTICAL:
 				st |= WS_VSCROLL | ES_AUTOVSCROLL;
 				break;

--- a/win32/dfl/tabcontrol.d
+++ b/win32/dfl/tabcontrol.d
@@ -112,7 +112,7 @@ class TabPage: Panel
 	+/
 	
 	
-	/+ package +/ /+ protected +/ int _rtype() // package
+	/+ package +/ /+ protected +/ override int _rtype() // package
 	{
 		return 4;
 	}


### PR DESCRIPTION
jp: -wをつけてコンパイルしようとすると出る大量の警告に対応。あと2.055で出た多くのdeprecatedマークにも対応もしました。
en: Supported -w switch. And, coped with many deprecated functions that appeared from dmd 2.055.
