### PR TITLE
Fixed an assert expression.

### DIFF
--- a/win32/dfl/drawing.d
+++ b/win32/dfl/drawing.d
@@ -2677,7 +2677,7 @@ class Graphics // docmain
 	// to the previous point.
 	final void drawLines(Pen pen, Point[] points)
 	{
-		assert(points.length < 2, "Not enough line points.");
+		assert(points.length >= 2, "Not enough line points.");
 		
 		HPEN prevPen;
 		int i;


### PR DESCRIPTION
Points more than two are necessary to draw a line.

NG: assert(points.length < 2, "Not enough line points.");
OK: assert(points.length >= 2, "Not enough line points.");
