### PR TITLE
Followed typedef deprecation.

### DIFF
--- a/win32/dfl/application.d
+++ b/win32/dfl/application.d
@@ -1831,7 +1831,7 @@ extern(Windows) LRESULT dflWndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lp
 
 version(CUSTOM_MSG_HOOK)
 {
-	typedef CWPRETSTRUCT CustomMsg;
+	alias CWPRETSTRUCT CustomMsg;
 	
 	
 	// Needs to be re-entrant.

--- a/win32/dfl/internal/_stdcwindows.d
+++ b/win32/dfl/internal/_stdcwindows.d
@@ -52,7 +52,7 @@ extern(Windows):
  alias uint UINT;
  alias uint *PUINT;
 
- typedef void *HANDLE;
+ alias void *HANDLE;
  alias void *PVOID;
  alias HANDLE HGLOBAL;
  alias HANDLE HLOCAL;

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -1723,7 +1723,7 @@ extern(Windows):
 	const DWORD LF_FACESIZE = 32;
 	
 	
-	typedef HANDLE HIMAGELIST;
+	alias HANDLE HIMAGELIST;
 	
 	
 	enum: UINT


### PR DESCRIPTION
jp: typedefは非推奨マークされました。代わりにaliasを使用することが推奨されます。
en: typedef keyword is marked as deprecated. It is recommended alias instead.
