### PR TITLE
Remove private from function declarations

### DIFF
--- a/win32/dfl/internal/utf.d
+++ b/win32/dfl/internal/utf.d
@@ -415,7 +415,7 @@ size_t toUnicodeLength(Dstring utf8)
 }
 
 
-private extern(Windows)
+extern(Windows)
 {
 	alias HWND function(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle,
 		int x, int y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance,


### PR DESCRIPTION
This change is backwards compatible and will be needed when 2.058 is released.
