### PR TITLE
Add onMoving event and onSizing event

### DIFF
--- a/win32/dfl/base.d
+++ b/win32/dfl/base.d
@@ -764,6 +764,107 @@ class CancelEventArgs: EventArgs
 	bool cncl;
 }
 
+///
+class SizingEventArgs: EventArgs
+{
+	///
+	// Initialize cancel to false.
+	this(Size sz) pure nothrow
+	{
+		_sz = sz;
+	}
+	
+	///
+	@property Size size() pure nothrow
+	{
+		return _sz;
+	}
+	
+	/// ditto
+	@property void size(Size sz) pure nothrow
+	{
+		_sz = sz;
+	}
+	
+	///
+	@property void width(size_t w) pure nothrow
+	{
+		_sz.width = w;
+	}
+	
+	/// ditto
+	@property size_t width() pure nothrow
+	{
+		return _sz.width;
+	}
+	
+	///
+	@property void height(size_t h) pure nothrow
+	{
+		_sz.height = h;
+	}
+	
+	/// ditto
+	@property size_t height() pure nothrow
+	{
+		return _sz.height;
+	}
+	
+	
+	private:
+	Size _sz;
+}
+
+///
+class MovingEventArgs: EventArgs
+{
+	///
+	// Initialize cancel to false.
+	this(Point loc) pure nothrow
+	{
+		_loc = loc;
+	}
+	
+	///
+	@property Point location() pure nothrow
+	{
+		return _loc;
+	}
+	
+	/// ditto
+	@property void location(Point loc) pure nothrow
+	{
+		_loc = loc;
+	}
+	
+	///
+	@property void x(size_t posX) pure nothrow
+	{
+		_loc.x = posX;
+	}
+	
+	/// ditto
+	@property size_t x() pure nothrow
+	{
+		return _loc.x;
+	}
+	
+	///
+	@property void y(size_t posY) pure nothrow
+	{
+		_loc.y = posY;
+	}
+	
+	/// ditto
+	@property size_t y() pure nothrow
+	{
+		return _loc.y;
+	}
+	
+	
+	private:
+	Point _loc;
+}
 
 ///
 class KeyEventArgs: EventArgs

--- a/win32/dfl/control.d
+++ b/win32/dfl/control.d
@@ -4132,6 +4132,11 @@ class Control: DObject, IWindow // docmain
 	}
 	
 	
+	protected void onMoving(MovingEventArgs cea)
+	{
+		moving(this, cea);
+	}
+	
 	///
 	protected void onMove(EventArgs ea)
 	{
@@ -4147,6 +4152,11 @@ class Control: DObject, IWindow // docmain
 	+/
 	alias onMove onLocationChanged;
 	
+	
+	protected void onSizing(SizingEventArgs cea)
+	{
+		sizing(this, cea);
+	}
 	
 	///
 	protected void onResize(EventArgs ea)
@@ -4730,31 +4740,28 @@ class Control: DObject, IWindow // docmain
 				}
 				break;
 			
-			/+
 			case WM_WINDOWPOSCHANGING:
 				{
 					WINDOWPOS* wp = cast(WINDOWPOS*)msg.lParam;
 					
-					/+
-					//if(!(wp.flags & SWP_NOSIZE))
-					if(width != wp.cx || height != wp.cy)
+					if (!(wp.flags & SWP_NOMOVE)
+					 && (location.x != wp.x || location.y != wp.y))
 					{
-						scope BeforeResizeEventArgs ea = new BeforeResizeEventArgs(wp.cx, wp.cy);
-						onBeforeResize(ea);
-						/+if(wp.cx == ea.width && wp.cy == ea.height)
-						{
-							wp.flags |= SWP_NOSIZE;
-						}
-						else+/
-						{
-							wp.cx = ea.width;
-							wp.cy = ea.height;
-						}
+						scope e = new MovingEventArgs(Point(wp.x, wp.y));
+						onMoving(e);
+						wp.x = e.x;
+						wp.y = e.y;
 					}
-					+/
+					if (!(wp.flags & SWP_NOSIZE)
+					 && (width != wp.cx || height != wp.cy))
+					{
+						scope e = new SizingEventArgs(Size(wp.cx, wp.cy));
+						onSizing(e);
+						wp.cx = e.width;
+						wp.cy = e.height;
+					}
 				}
 				break;
-			+/
 			
 			case WM_MOUSEMOVE:
 				if(_clicking)
@@ -5928,6 +5935,8 @@ class Control: DObject, IWindow // docmain
 	Event!(Control, MouseEventArgs) mouseUp; ///
 	//MouseEventHandler mouseWheel;
 	Event!(Control, MouseEventArgs) mouseWheel; ///
+	//EventHandler moving;
+	Event!(Control, MovingEventArgs) moving; ///
 	//EventHandler move;
 	Event!(Control, EventArgs) move; ///
 	//EventHandler locationChanged;
@@ -5936,6 +5945,8 @@ class Control: DObject, IWindow // docmain
 	Event!(Control, PaintEventArgs) paint; ///
 	//EventHandler parentChanged;
 	Event!(Control, EventArgs) parentChanged; ///
+	//EventHandler sizing;
+	Event!(Control, SizingEventArgs) sizing; ///
 	//EventHandler resize;
 	Event!(Control, EventArgs) resize; ///
 	//EventHandler sizeChanged;


### PR DESCRIPTION
I tried to enhancement of onMoving event and onSizing event.
Demonstration of this change runs by the following programs:

```D
import dfl.all;
pragma(lib, "dfl");

void main()
{
	Application.enableVisualStyles();
	auto f1 = new Form;
	auto f2 = new Form;
	bool lock = false;
	void mirmovunlock(Control c, EventArgs e)
	{
		lock = false;
	}
	void mirmov(Control c, MovingEventArgs e)
	{
		auto f = c is f1 ? f2 : f1;
		if (!lock)
		{
			lock = true;
			immutable x = e.x + f.location.x - c.location.x,
			          y = e.y + f.location.y - c.location.y;
			
			f.location = Point(x, y);
		}
	}
	void mirsz(Control c, SizingEventArgs e)
	{
		auto f = c is f1 ? f2 : f1;
		if (!lock)
		{
			lock = true;
			immutable width  = e.width  + f.width  - c.width,
			          height = e.height + f.height - c.height;
			
			f.size = Size(width, height);
		}
	}
	f1.moving ~= &mirmov;
	f2.moving ~= &mirmov;
	f1.sizing ~= &mirsz;
	f2.sizing ~= &mirsz;
	f1.move   ~= &mirmovunlock;
	f2.move   ~= &mirmovunlock;
	f1.resize ~= &mirmovunlock;
	f2.resize ~= &mirmovunlock;
	f1.show();
	f2.show();
	Application.run(f1);
}
```

I wrote this function in reference to onBeforeResize event that is commented out.
Because I don’t know why these codes commented out, this codes may bring in some enbug.
If it is possible, please review this change.