### PR TITLE
DFL64 rev.2

### DIFF
--- a/win32/dfl/application.d
+++ b/win32/dfl/application.d
@@ -355,7 +355,7 @@ final class Application // docmain
 	/// ditto
 	void removeMessageFilter(IMessageFilter mf)
 	{
-		uint i;
+		size_t i;
 		for(i = 0; i != filters.length; i++)
 		{
 			if(mf is filters[i])

--- a/win32/dfl/application.d
+++ b/win32/dfl/application.d
@@ -185,7 +185,7 @@ final class Application // docmain
 							`type="win32" `
 							`name="Microsoft.Windows.Common-Controls" `
 							`version="6.0.0.0" `
-							`processorArchitecture="X86" `
+							`processorArchitecture="*" `
 							`publicKeyToken="6595b64144ccf1df" `
 							`language="*" `
 						`/>` "\r\n"

--- a/win32/dfl/application.d
+++ b/win32/dfl/application.d
@@ -1318,7 +1318,7 @@ final class Application // docmain
 	}
 	
 	
-	private UINT gctimer = 0;
+	private UINT_PTR gctimer = 0;
 	private DWORD gcinfo = 1;
 	
 	
@@ -1669,7 +1669,7 @@ final class Application // docmain
 package:
 
 
-extern(Windows) void _gcTimeout(HWND hwnd, UINT uMsg, UINT idEvent, DWORD dwTime) nothrow
+extern(Windows) void _gcTimeout(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime) nothrow
 {
 	KillTimer(hwnd, Application.gctimer);
 	Application.gctimer = 0;

--- a/win32/dfl/base.d
+++ b/win32/dfl/base.d
@@ -412,7 +412,7 @@ abstract class WaitHandle
 			hs[i] = wh.handle;
 		}
 		
-		result = WaitForMultipleObjects(handles.length, hs, waitall, msTimeout);
+		result = WaitForMultipleObjects(handles.length.toI32, hs, waitall, msTimeout);
 		if(WAIT_FAILED == result)
 		{
 			fail:

--- a/win32/dfl/button.d
+++ b/win32/dfl/button.d
@@ -189,7 +189,7 @@ abstract class ButtonBase: ControlSuperClass // docmain
 		/+
 		// Done in createParams() now.
 		if(isdef)
-			SetWindowLongA(handle, GWL_ID, IDOK);
+			SetWindowLongPtrA(handle, GWL_ID, IDOK);
 		+/
 	}
 	+/

--- a/win32/dfl/clippingform.d
+++ b/win32/dfl/clippingform.d
@@ -1,6 +1,7 @@
 ﻿module dfl.clippingform;
 
 private import dfl.all, dfl.internal.winapi;
+private import dfl.internal.dlib : toI32;
 private import core.memory;
 
 private extern (Windows)
@@ -122,8 +123,8 @@ public:
 		{
 			dwSize = RGNDATAHEADER.sizeof;
 			iType  = RDH_RECTANGLES;
-			nRgnSize = RGNDATAHEADER.sizeof + RECT.sizeof*nCount;
-			rcBound = RECT(0,0,_width,_height);
+			nRgnSize = RGNDATAHEADER.sizeof.toI32 + RECT.sizeof.toI32*nCount.toI32;
+			rcBound = RECT(0,0,_width.toI32,_height.toI32);
 		}
 		if (auto hRgn = ExtCreateRegion(null, _rgn.rdh.nRgnSize, _rgn))
 		{
@@ -143,8 +144,8 @@ public:
 		with(bi)
 		{
 			biSize        = BITMAPINFOHEADER.sizeof;
-			biWidth       = w;
-			biHeight      = h;
+			biWidth       = w.toI32;
+			biHeight      = h.toI32;
 			biPlanes      = 1;
 			biBitCount    = 32;
 			biCompression = BI_RGB;
@@ -153,7 +154,7 @@ public:
 		COLORREF tr;
 		for (int y = 1; y < h; ++y)
 		{
-			GetDIBits(hDC, hBitmap, h-y, 1, pxs.ptr, cast(BITMAPINFO*)&bi, DIB_RGB_COLORS);
+			GetDIBits(hDC, hBitmap, h.toI32-y, 1, pxs.ptr, cast(BITMAPINFO*)&bi, DIB_RGB_COLORS);
 			if (y == 1) tr = pxs[0];
 			for (int x = 0; x < w; x++)
 			{

--- a/win32/dfl/collections.d
+++ b/win32/dfl/collections.d
@@ -56,7 +56,7 @@ template ListWrapArray(TValue, alias Array,
 	
 	
 	///
-	void opIndexAssign(TValue value, int index)
+	void opIndexAssign(TValue value, size_t index)
 	{
 		TValue oldval = Array[index];
 		ItemRemovingCallback(index, oldval); // Removing.
@@ -78,7 +78,7 @@ template ListWrapArray(TValue, alias Array,
 	static if(OVERLOAD_OBJECT)
 	{
 		/// ditto
-		void opIndexAssign(Object value, int index)
+		void opIndexAssign(Object value, size_t index)
 		{
 			TValue tval;
 			tval = cast(TValue)value;
@@ -92,7 +92,7 @@ template ListWrapArray(TValue, alias Array,
 	static if(OVERLOAD_STRING)
 	{
 		/// ditto
-		void opIndexAssign(Dstring value, int index)
+		void opIndexAssign(Dstring value, size_t index)
 		{
 			return opIndexAssign(new TValueString(value), index);
 		}
@@ -100,7 +100,7 @@ template ListWrapArray(TValue, alias Array,
 	
 	
 	///
-	@property TValue opIndex(int index) // getter
+	@property TValue opIndex(size_t index) // getter
 	{
 		return Array[index];
 	}
@@ -240,7 +240,7 @@ template ListWrapArray(TValue, alias Array,
 			}
 			else
 			{
-				foreach(size_t idx, TValue onval; Array)
+				foreach(int idx, TValue onval; Array)
 				{
 					if(onval == value) // TValue must have opEquals.
 						return idx;
@@ -260,12 +260,12 @@ template ListWrapArray(TValue, alias Array,
 				static if(is(TValue == TValueString))
 				{
 					if(onval == value) // TValue must have opEquals.
-						return idx;
+						return idx.toI32;
 				}
 				else
 				{
 					if(getObjectString(onval) == value)
-						return idx;
+						return idx.toI32;
 				}
 			}
 			return -1;
@@ -275,8 +275,8 @@ template ListWrapArray(TValue, alias Array,
 	
 	private final void _insert(int index, TValue value)
 	{
-		if(index > Array.length)
-			index = Array.length;
+		if(index > Array.length.toI32)
+			index = Array.length.toI32;
 		ItemAddingCallback(index, value); // Adding.
 		static if(COW)
 		{

--- a/win32/dfl/colordialog.d
+++ b/win32/dfl/colordialog.d
@@ -20,7 +20,7 @@ class ColorDialog: CommonDialog // docmain
 		cc.Flags = INIT_FLAGS;
 		cc.rgbResult = Color.empty.toArgb();
 		cc.lCustData = cast(typeof(cc.lCustData))cast(void*)this;
-		cc.lpfnHook = cast(typeof(cc.lpfnHook))&ccHookProc;
+		cc.lpfnHook = /*cast(typeof(cc.lpfnHook))*/&ccHookProc;
 		_initcust();
 	}
 	
@@ -202,11 +202,11 @@ class ColorDialog: CommonDialog // docmain
 }
 
 
-private extern(Windows) UINT ccHookProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
+private extern(Windows) UINT_PTR ccHookProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) nothrow
 {
 	enum PROP_STR = "DFL_ColorDialog";
 	ColorDialog cd;
-	UINT result = 0;
+	UINT_PTR result = 0;
 	
 	try
 	{
@@ -224,7 +224,7 @@ private extern(Windows) UINT ccHookProc(HWND hwnd, UINT msg, WPARAM wparam, LPAR
 		
 		if(cd)
 		{
-			result = cast(UINT)cd.hookProc(hwnd, msg, wparam, lparam);
+			result = cd.hookProc(hwnd, msg, wparam, lparam);
 		}
 	}
 	catch(DThrowable e)

--- a/win32/dfl/combobox.d
+++ b/win32/dfl/combobox.d
@@ -299,7 +299,7 @@ class ComboBox: ListControl // docmain
 	///
 	final int getItemHeight(int idx)
 	{
-		int result = prevwproc(CB_GETITEMHEIGHT, idx, 0);
+		int result = prevwproc(CB_GETITEMHEIGHT, idx, 0).toI32;
 		if(CB_ERR == result)
 			throw new DflException("Unable to obtain item height");
 		return result;
@@ -436,7 +436,7 @@ class ComboBox: ListControl // docmain
 		if(!(ctrlStyle & ControlStyles.CACHE_TEXT) && isHandleCreated)
 			//return cast(uint)SendMessageA(handle, WM_GETTEXTLENGTH, 0, 0);
 			return cast(uint)dfl.internal.utf.sendMessage(handle, WM_GETTEXTLENGTH, 0, 0);
-		return wtext.length;
+		return wtext.length.toI32;
 	}
 	
 	
@@ -969,7 +969,7 @@ class ComboBox: ListControl // docmain
 				return;
 			
 			case CB_LIMITTEXT:
-				maxLength = msg.wParam;
+				maxLength = msg.wParam.toI32;
 				return;
 			
 			case WM_SETFOCUS:

--- a/win32/dfl/combobox.d
+++ b/win32/dfl/combobox.d
@@ -672,7 +672,7 @@ class ComboBox: ListControl // docmain
 		
 		// Set the Ctrl ID to the HWND so that it is unique
 		// and WM_MEASUREITEM will work properly.
-		SetWindowLongA(hwnd, GWL_ID, cast(LONG)hwnd);
+		SetWindowLongPtrA(hwnd, GWL_ID, cast(LONG_PTR)hwnd);
 		
 		//prevwproc(EM_SETLIMITTEXT, cast(WPARAM)lim, 0);
 		maxLength = lim; // Call virtual function.

--- a/win32/dfl/combobox.d
+++ b/win32/dfl/combobox.d
@@ -252,9 +252,9 @@ class ComboBox: ListControl // docmain
 		if(isHandleCreated)
 		{
 			if(dfl.internal.utf.useUnicode)
-				result = prevwproc(CB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str));
+				result = prevwproc(CB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str)).toI32;
 			else
-				result = prevwproc(CB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str));
+				result = prevwproc(CB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str)).toI32;
 			if(result == CB_ERR) // Redundant.
 				result = NO_MATCHES;
 		}
@@ -279,9 +279,9 @@ class ComboBox: ListControl // docmain
 		if(isHandleCreated)
 		{
 			if(dfl.internal.utf.useUnicode)
-				result = prevwproc(CB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str));
+				result = prevwproc(CB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str)).toI32;
 			else
-				result = prevwproc(CB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str));
+				result = prevwproc(CB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str)).toI32;
 			if(result == CB_ERR) // Redundant.
 				result = NO_MATCHES;
 		}
@@ -586,7 +586,7 @@ class ComboBox: ListControl // docmain
 		
 		LRESULT insert2(WPARAM idx, Dstring val)
 		{
-			insert(idx, val);
+			insert(idx.toI32, val);
 			return idx;
 		}
 		
@@ -596,7 +596,7 @@ class ComboBox: ListControl // docmain
 			int i;
 			if(lbox.sorted)
 			{
-				for(i = 0; i != _items.length; i++)
+				for(i = 0; i != _items.length.toI32; i++)
 				{
 					if(val < _items[i])
 						break;
@@ -604,7 +604,7 @@ class ComboBox: ListControl // docmain
 			}
 			else
 			{
-				i = _items.length;
+				i = _items.length.toI32;
 			}
 			
 			insert(i, val);
@@ -951,7 +951,7 @@ class ComboBox: ListControl // docmain
 				return;
 			
 			case CB_DELETESTRING:
-				icollection.removeAt(msg.wParam);
+				icollection.removeAt(msg.wParam.toI32);
 				msg.result = icollection.length;
 				return;
 			

--- a/win32/dfl/control.d
+++ b/win32/dfl/control.d
@@ -3647,7 +3647,7 @@ class Control: DObject, IWindow // docmain
 	///
 	static bool isMnemonic(dchar charCode, Dstring text)
 	{
-		uint ui;
+		size_t ui;
 		for(ui = 0; ui != text.length; ui++)
 		{
 			if('&' == text[ui])

--- a/win32/dfl/control.d
+++ b/win32/dfl/control.d
@@ -708,7 +708,7 @@ class Control: DObject, IWindow // docmain
 			}
 			else
 			{
-				return children.length;
+				return children.length.toI32;
 			}
 		}
 		
@@ -1524,7 +1524,7 @@ class Control: DObject, IWindow // docmain
 				{
 					SendMessageA(hwnd, WM_SETCURSOR, cast(WPARAM)hwnd,
 						MAKELPARAM(
-							SendMessageA(hwnd, WM_NCHITTEST, 0, MAKELPARAM(curpt.x, curpt.y)),
+							SendMessageA(hwnd, WM_NCHITTEST, 0, MAKELPARAM(curpt.x, curpt.y)).toI32,
 							WM_MOUSEMOVE)
 							);
 				}
@@ -3866,7 +3866,7 @@ class Control: DObject, IWindow // docmain
 				return false;
 			xiter--;
 			
-			LONG st = GetWindowLongPtrA(hw, GWL_STYLE);
+			LONG st = GetWindowLongPtrA(hw, GWL_STYLE).toI32;
 			if(!(st & WS_VISIBLE))
 				continue;
 			if(st & WS_DISABLED)
@@ -5629,7 +5629,7 @@ class Control: DObject, IWindow // docmain
 					if((wp.flags & (SWP_SHOWWINDOW | SWP_HIDEWINDOW)) || !(wp.flags & SWP_NOSIZE))
 					{
 						DWORD rstyle;
-						rstyle = GetWindowLongPtrA(msg.hWnd, GWL_STYLE);
+						rstyle = GetWindowLongPtrA(msg.hWnd, GWL_STYLE).toI32;
 						rstyle &= WS_MAXIMIZE | WS_MINIMIZE;
 						wstyle &= ~(WS_MAXIMIZE | WS_MINIMIZE);
 						wstyle |= rstyle;
@@ -5721,7 +5721,7 @@ class Control: DObject, IWindow // docmain
 				else
 					wstyle |= WS_DISABLED;
 				+/
-				wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
+				wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE).toI32;
 				break;
 			
 			/+
@@ -7188,7 +7188,7 @@ class Control: DObject, IWindow // docmain
 		if(isHandleCreated)
 		{
 			// Always fetch because it's not guaranteed to be accurate.
-			wclassStyle = _fetchClassLongPtr();
+			wclassStyle = _fetchClassLongPtr().toI32;
 		}
 		
 		return wclassStyle;

--- a/win32/dfl/control.d
+++ b/win32/dfl/control.d
@@ -2788,7 +2788,7 @@ class Control: DObject, IWindow // docmain
 	private DWORD _fetchVisible()
 	{
 		//return IsWindowVisible(hwnd) != FALSE;
-		wstyle = GetWindowLongA(hwnd, GWL_STYLE);
+		wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
 		return wstyle & WS_VISIBLE;
 	}
 	+/
@@ -2804,7 +2804,7 @@ class Control: DObject, IWindow // docmain
 	final @property bool visible() // getter
 	{
 		//if(isHandleCreated)
-		//	wstyle = GetWindowLongA(hwnd, GWL_STYLE); // ...
+		//	wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE); // ...
 		//return (wstyle & WS_VISIBLE) != 0;
 		return (cbits & CBits.VISIBLE) != 0;
 	}
@@ -3866,7 +3866,7 @@ class Control: DObject, IWindow // docmain
 				return false;
 			xiter--;
 			
-			LONG st = GetWindowLongA(hw, GWL_STYLE);
+			LONG st = GetWindowLongPtrA(hw, GWL_STYLE);
 			if(!(st & WS_VISIBLE))
 				continue;
 			if(st & WS_DISABLED)
@@ -3877,7 +3877,7 @@ class Control: DObject, IWindow // docmain
 			
 			if(nested)
 			{
-				//LONG exst = GetWindowLongA(hw, GWL_EXSTYLE);
+				//LONG exst = GetWindowLongPtrA(hw, GWL_EXSTYLE);
 				//if(exst & WS_EX_CONTROLPARENT) // It's no longer added.
 				{
 					HWND hwc = GetWindow(hw, GW_CHILD);
@@ -3931,7 +3931,7 @@ class Control: DObject, IWindow // docmain
 					}
 					else
 					{
-						if(!tabStopOnly || (GetWindowLongA(hw, GWL_STYLE) & WS_TABSTOP))
+						if(!tabStopOnly || (GetWindowLongPtrA(hw, GWL_STYLE) & WS_TABSTOP))
 						{
 							if(!selectableOnly || _isHwndControlSel(hw))
 							{
@@ -3978,7 +3978,7 @@ class Control: DObject, IWindow // docmain
 							return false; // Break.
 						}
 					}
-					if(!tabStopOnly || (GetWindowLongA(hw, GWL_STYLE) & WS_TABSTOP))
+					if(!tabStopOnly || (GetWindowLongPtrA(hw, GWL_STYLE) & WS_TABSTOP))
 					{
 						if(!selectableOnly || _isHwndControlSel(hw))
 						{
@@ -4817,13 +4817,13 @@ class Control: DObject, IWindow // docmain
 					cur = cursor;
 					if(cur)
 					{
-						if(cast(HCURSOR)GetClassLongA(hwnd, GCL_HCURSOR) != cur.handle)
-							SetClassLongA(hwnd, GCL_HCURSOR, cast(LONG)cur.handle);
+						if(cast(HCURSOR)GetClassLongPtrA(hwnd, GCL_HCURSOR) != cur.handle)
+							SetClassLongPtrA(hwnd, GCL_HCURSOR, cast(LONG_PTR)cur.handle);
 					}
 					else
 					{
-						if(cast(HCURSOR)GetClassLongA(hwnd, GCL_HCURSOR) != HCURSOR.init)
-							SetClassLongA(hwnd, GCL_HCURSOR, cast(LONG)cast(HCURSOR)null);
+						if(cast(HCURSOR)GetClassLongPtrA(hwnd, GCL_HCURSOR) != HCURSOR.init)
+							SetClassLongPtrA(hwnd, GCL_HCURSOR, cast(LONG_PTR)cast(HCURSOR)null);
 					}
 					Control.defWndProc(msg);
 					return;
@@ -5602,10 +5602,10 @@ class Control: DObject, IWindow // docmain
 					
 					if(!recreatingHandle)
 					{
-						//wstyle = GetWindowLongA(hwnd, GWL_STYLE); // ..WM_SHOWWINDOW.
+						//wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE); // ..WM_SHOWWINDOW.
 						if(wp.flags & (SWP_HIDEWINDOW | SWP_SHOWWINDOW))
 						{
-							//wstyle = GetWindowLongA(hwnd, GWL_STYLE);
+							//wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
 							cbits |= CBits.VISIBLE;
 							wstyle |= WS_VISIBLE;
 							if(wp.flags & SWP_HIDEWINDOW) // Hiding.
@@ -5629,7 +5629,7 @@ class Control: DObject, IWindow // docmain
 					if((wp.flags & (SWP_SHOWWINDOW | SWP_HIDEWINDOW)) || !(wp.flags & SWP_NOSIZE))
 					{
 						DWORD rstyle;
-						rstyle = GetWindowLongA(msg.hWnd, GWL_STYLE);
+						rstyle = GetWindowLongPtrA(msg.hWnd, GWL_STYLE);
 						rstyle &= WS_MAXIMIZE | WS_MINIMIZE;
 						wstyle &= ~(WS_MAXIMIZE | WS_MINIMIZE);
 						wstyle |= rstyle;
@@ -5674,7 +5674,7 @@ class Control: DObject, IWindow // docmain
 					{
 						cbits &= ~(CBits.SW_SHOWN | CBits.SW_HIDDEN);
 						DWORD rstyle;
-						rstyle = GetWindowLongA(msg.hWnd, GWL_STYLE);
+						rstyle = GetWindowLongPtrA(msg.hWnd, GWL_STYLE);
 						if(cast(BOOL)msg.wParam)
 						{
 							//wstyle |= WS_VISIBLE;
@@ -5706,7 +5706,7 @@ class Control: DObject, IWindow // docmain
 						}
 					}
 					+/
-					wstyle = GetWindowLongA(msg.hWnd, GWL_STYLE);
+					wstyle = GetWindowLongPtrA(msg.hWnd, GWL_STYLE);
 					//if(cbits & CBits.FVISIBLE)
 					//	wstyle |= WS_VISIBLE;
 				}
@@ -5721,7 +5721,7 @@ class Control: DObject, IWindow // docmain
 				else
 					wstyle |= WS_DISABLED;
 				+/
-				wstyle = GetWindowLongA(hwnd, GWL_STYLE);
+				wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
 				break;
 			
 			/+
@@ -5774,8 +5774,8 @@ class Control: DObject, IWindow // docmain
 					+/
 					
 					// If class style was changed, update.
-					if(_fetchClassLong() != wclassStyle)
-						SetClassLongA(hwnd, GCL_STYLE, wclassStyle);
+					if(_fetchClassLongPtr() != wclassStyle)
+						SetClassLongPtrA(hwnd, GCL_STYLE, wclassStyle);
 					
 					// Need to update clientSize in case of styles in createParams().
 					wclientsz = _fetchClientSize();
@@ -6528,7 +6528,7 @@ class Control: DObject, IWindow // docmain
 		if(!(ctrlStyle & ControlStyles.CACHE_TEXT))
 			wtext = _fetchText();
 		
-		//wclassStyle = _fetchClassLong(); // ?
+		//wclassStyle = _fetchClassLongPtr(); // ?
 		
 		// Fetch children.
 		Control[] ccs;
@@ -6800,7 +6800,7 @@ class Control: DObject, IWindow // docmain
 	{
 		if(isHandleCreated)
 		{
-			//wstyle = GetWindowLongA(hwnd, GWL_STYLE);
+			//wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
 			if(visible == byes)
 				return;
 			
@@ -7092,7 +7092,7 @@ class Control: DObject, IWindow // docmain
 	
 	@property LONG _exStyle()
 	{
-		// return GetWindowLongA(hwnd, GWL_EXSTYLE);
+		// return GetWindowLongPtrA(hwnd, GWL_EXSTYLE);
 		return wexstyle;
 	}
 	
@@ -7101,7 +7101,7 @@ class Control: DObject, IWindow // docmain
 	{
 		if(isHandleCreated)
 		{
-			SetWindowLongA(hwnd, GWL_EXSTYLE, wl);
+			SetWindowLongPtrA(hwnd, GWL_EXSTYLE, wl);
 		}
 		
 		wexstyle = wl;
@@ -7110,7 +7110,7 @@ class Control: DObject, IWindow // docmain
 	
 	@property LONG _style()
 	{
-		// return GetWindowLongA(hwnd, GWL_STYLE);
+		// return GetWindowLongPtrA(hwnd, GWL_STYLE);
 		return wstyle;
 	}
 	
@@ -7119,7 +7119,7 @@ class Control: DObject, IWindow // docmain
 	{
 		if(isHandleCreated)
 		{
-			SetWindowLongA(hwnd, GWL_STYLE, wl);
+			SetWindowLongPtrA(hwnd, GWL_STYLE, wl);
 		}
 		
 		wstyle = wl;
@@ -7174,21 +7174,21 @@ class Control: DObject, IWindow // docmain
 	}
 	
 	
-	LONG _fetchClassLong()
+	LONG_PTR _fetchClassLongPtr()
 	{
-		return GetClassLongA(hwnd, GCL_STYLE);
+		return GetClassLongPtrA(hwnd, GCL_STYLE);
 	}
 	
 	
 	LONG _classStyle()
 	{
-		// return GetClassLongA(hwnd, GCL_STYLE);
+		// return GetClassLongPtrA(hwnd, GCL_STYLE);
 		// return wclassStyle;
 		
 		if(isHandleCreated)
 		{
 			// Always fetch because it's not guaranteed to be accurate.
-			wclassStyle = _fetchClassLong();
+			wclassStyle = _fetchClassLongPtr();
 		}
 		
 		return wclassStyle;
@@ -7199,7 +7199,7 @@ class Control: DObject, IWindow // docmain
 	{
 		if(isHandleCreated)
 		{
-			SetClassLongA(hwnd, GCL_STYLE, cl);
+			SetClassLongPtrA(hwnd, GCL_STYLE, cl);
 		}
 		
 		wclassStyle = cl;

--- a/win32/dfl/data.d
+++ b/win32/dfl/data.d
@@ -814,7 +814,7 @@ class DataObject: dfl.data.IDataObject // docmain
 			{
 				if(fix && all[i].obj.info == typeid(_DataConvert))
 					fixPairEntry(all[i]);
-				return i;
+				return i.toI32;
 			}
 		}
 		return -1;
@@ -1178,7 +1178,7 @@ package class EnumDataObjectFORMATETC: DflComObject, IEnumFORMATETC
 				if(end > fmts.length)
 				{
 					result = S_FALSE; // ?
-					end = fmts.length;
+					end = fmts.length.toI32;
 					
 					if(pceltFetched)
 						*pceltFetched = end - idx;
@@ -1346,7 +1346,7 @@ class DtoComDataObject: DflComObject, dfl.internal.wincom.IDataObject // package
 				
 				//src = data.value;
 				src = DataFormats.getClipboardValueFromData(dfmt.id, data);
-				hg = GlobalAlloc(GMEM_SHARE, src.length);
+				hg = GlobalAlloc(GMEM_SHARE, src.length.toI32);
 				if(!hg)
 				{
 					result = STG_E_MEDIUMFULL;

--- a/win32/dfl/data.d
+++ b/win32/dfl/data.d
@@ -494,7 +494,7 @@ private template stopAtNull(T)
 {
 	T[] stopAtNull(T[] array)
 	{
-		int i;
+		size_t i;
 		for(i = 0; i != array.length; i++)
 		{
 			if(!array[i])
@@ -807,7 +807,7 @@ class DataObject: dfl.data.IDataObject // docmain
 	
 	int find(Dstring fmt, bool fix = true)
 	{
-		int i;
+		size_t i;
 		for(i = 0; i != all.length; i++)
 		{
 			if(!stringICmp(all[i].fmt, fmt))

--- a/win32/dfl/drawing.d
+++ b/win32/dfl/drawing.d
@@ -2799,7 +2799,7 @@ class Graphics // docmain
 		{
 			LineTo(hdc, points[i].x, points[i].y);
 			
-			if(++i == points.length)
+			if(++i == points.length.toI32)
 				break;
 		}
 		
@@ -2878,7 +2878,7 @@ class Graphics // docmain
 		static assert(Point.sizeof == POINT.sizeof);
 		cpts = cast(POINT*)cast(Point*)points;
 		
-		PolyBezier(hdc, cpts, points.length);
+		PolyBezier(hdc, cpts, points.length.toI32);
 		
 		// Reset stuff.
 		SelectObject(hdc, prevPen);
@@ -2934,7 +2934,7 @@ class Graphics // docmain
 		static assert(Point.sizeof == POINT.sizeof);
 		cpts = cast(POINT*)cast(Point*)points;
 		
-		Polygon(hdc, cpts, points.length);
+		Polygon(hdc, cpts, points.length.toI32);
 		
 		// Reset stuff.
 		SelectObject(hdc, prevPen);

--- a/win32/dfl/drawing.d
+++ b/win32/dfl/drawing.d
@@ -2409,7 +2409,7 @@ class Graphics // docmain
 	
 	// Used internally.
 	// vSplit=true means the move grip moves left to right; false means top to bottom.
-	final void drawMoveGrip(Rect movableArea, bool vSplit = true, size_t count = 5) // package
+	final void drawMoveGrip(Rect movableArea, bool vSplit = true, uint count = 5) // package
 	{
 		enum MSPACE = 4;
 		enum MWIDTH = 3;

--- a/win32/dfl/filedialog.d
+++ b/win32/dfl/filedialog.d
@@ -472,7 +472,7 @@ abstract class FileDialog: CommonDialog // docmain
 								onFileOk(cea);
 								if(cea.cancel)
 								{
-									SetWindowLongA(hwnd, DWL_MSGRESULT, 1);
+									SetWindowLongPtrA(hwnd, DWL_MSGRESULT, 1);
 									return 1;
 								}
 							}

--- a/win32/dfl/filedialog.d
+++ b/win32/dfl/filedialog.d
@@ -530,7 +530,7 @@ abstract class FileDialog: CommonDialog // docmain
 				buf[ts.length] = 0;
 			}
 			
-			ofnw.nMaxFile = buf.length;
+			ofnw.nMaxFile = buf.length.toI32;
 			ofnw.lpstrFile = buf.ptr;
 		}
 		else
@@ -546,7 +546,7 @@ abstract class FileDialog: CommonDialog // docmain
 				buf[ts.length] = 0;
 			}
 			
-			ofna.nMaxFile = buf.length;
+			ofna.nMaxFile = buf.length.toI32;
 			ofna.lpstrFile = buf.ptr;
 		}
 		

--- a/win32/dfl/fontdialog.d
+++ b/win32/dfl/fontdialog.d
@@ -27,7 +27,7 @@ class FontDialog: CommonDialog
 		cf.Flags = INIT_FLAGS;
 		cf.lpLogFont = cast(typeof(cf.lpLogFont))&lfw;
 		cf.lCustData = cast(typeof(cf.lCustData))cast(void*)this;
-		cf.lpfnHook = &fondHookProc;
+		cf.lpfnHook = &fontHookProc;
 		cf.rgbColors = 0;
 	}
 	
@@ -418,11 +418,11 @@ class FontDialog: CommonDialog
 // WM_CHOOSEFONT_SETFLAGS to update flags after dialog creation ... ?
 
 
-private extern(Windows) UINT fondHookProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) nothrow
+private extern(Windows) UINT_PTR fontHookProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) nothrow
 {
 	enum PROP_STR = "DFL_FontDialog";
 	FontDialog fd;
-	LRESULT result = 0;
+	UINT_PTR result = 0;
 	
 	try
 	{

--- a/win32/dfl/form.d
+++ b/win32/dfl/form.d
@@ -1749,7 +1749,7 @@ class Form: ContainerControl, IDialogResult // docmain
 					//wstyle = wstyle & ~(WS_MINIMIZE | WS_MAXIMIZE);
 					break;
 			}
-			//wstyle = GetWindowLongA(hwnd, GWL_STYLE);
+			//wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
 		}
 		else
 		{
@@ -1774,7 +1774,7 @@ class Form: ContainerControl, IDialogResult // docmain
 	final @property FormWindowState windowState() // getter
 	{
 		LONG wl;
-		//wl = wstyle = GetWindowLongA(hwnd, GWL_STYLE);
+		//wl = wstyle = GetWindowLongPtrA(hwnd, GWL_STYLE);
 		wl = _style();
 		
 		if(wl & WS_MAXIMIZE)
@@ -2079,7 +2079,7 @@ class Form: ContainerControl, IDialogResult // docmain
 		{
 			if(sowner)
 			{
-				LONG owl = GetWindowLongA(sowner, GWL_STYLE);
+				LONG owl = GetWindowLongPtrA(sowner, GWL_STYLE);
 				if(owl & WS_CHILD)
 					goto bad_owner;
 				
@@ -2298,8 +2298,8 @@ class Form: ContainerControl, IDialogResult // docmain
 			//case WM_CREATE: // WM_NCCREATE seems like a better choice.
 			case WM_NCCREATE:
 				// Make sure Windows doesn't magically change the styles.
-				SetWindowLongA(hwnd, GWL_EXSTYLE, wexstyle);
-				SetWindowLongA(hwnd, GWL_STYLE, wstyle & ~WS_VISIBLE);
+				SetWindowLongPtrA(hwnd, GWL_EXSTYLE, wexstyle);
+				SetWindowLongPtrA(hwnd, GWL_STYLE, wstyle & ~WS_VISIBLE);
 				
 				SetWindowPos(hwnd, HWND.init, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOMOVE
 					| SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE); // Recalculate the frame.
@@ -2768,7 +2768,7 @@ class Form: ContainerControl, IDialogResult // docmain
 					enumChildWindows(msg.hWnd,
 						(HWND hw)
 						{
-							auto wl = GetWindowLongA(hw, GWL_STYLE);
+							auto wl = GetWindowLongPtrA(hw, GWL_STYLE);
 							if(((WS_VISIBLE | WS_TABSTOP) == ((WS_VISIBLE | WS_TABSTOP) & wl))
 								&& !(WS_DISABLED & wl))
 							{

--- a/win32/dfl/form.d
+++ b/win32/dfl/form.d
@@ -2079,7 +2079,7 @@ class Form: ContainerControl, IDialogResult // docmain
 		{
 			if(sowner)
 			{
-				LONG owl = GetWindowLongPtrA(sowner, GWL_STYLE);
+				LONG owl = GetWindowLongPtrA(sowner, GWL_STYLE).toI32;
 				if(owl & WS_CHILD)
 					goto bad_owner;
 				

--- a/win32/dfl/imagelist.d
+++ b/win32/dfl/imagelist.d
@@ -5,7 +5,7 @@
 ///
 module dfl.imagelist;
 
-import dfl.base, dfl.drawing, dfl.internal.winapi;
+import dfl.base, dfl.drawing, dfl.internal.winapi, dfl.internal.dlib;
 import dfl.collections;
 
 
@@ -27,7 +27,7 @@ else
 			
 			void insert(int index, Image img)
 			{
-				if(index >= _images.length)
+				if(index >= _images.length.toI32)
 				{
 					add(img);
 				}
@@ -207,7 +207,7 @@ else
 					}
 					else
 					{
-						imageListRemove(handle, idx);
+						imageListRemove(handle, idx.toI32);
 					}
 				}
 			}
@@ -403,7 +403,7 @@ else
 			}
 			
 			// Note: cGrow is not a limit, but how many images to preallocate each grow.
-			_hil = imageListCreate(_w, _h, flags, _cimages._images.length, 4 + _cimages._images.length / 4);
+			_hil = imageListCreate(_w, _h, flags, _cimages._images.length.toI32, 4 + _cimages._images.length.toI32 / 4);
 			if(!_hil)
 				throw new DflException("Unable to create image list");
 			

--- a/win32/dfl/internal/com.d
+++ b/win32/dfl/internal/com.d
@@ -33,13 +33,13 @@ class DflComObject: ComObject // package
 	override ULONG AddRef()
 	{
 		//cprintf("AddRef `%.*s`\n", cast(int)toString().length, toString().ptr);
-		return C_refCountInc(cast(void*)this);
+		return C_refCountInc(cast(void*)this).toI32;
 	}
 	
 	override ULONG Release()
 	{
 		//cprintf("Release `%.*s`\n", cast(int)toString().length, toString().ptr);
-		return C_refCountDec(cast(void*)this);
+		return C_refCountDec(cast(void*)this).toI32;
 	}
 }
 
@@ -89,7 +89,7 @@ class DStreamToIStream: DflComObject, dfl.internal.wincom.IStream
 		
 		try
 		{
-			read = stm.readBlock(pv, cb);
+			read = stm.readBlock(pv, cb).toI32;
 		}
 		catch(DStreamException e)
 		{
@@ -113,7 +113,7 @@ class DStreamToIStream: DflComObject, dfl.internal.wincom.IStream
 		{
 			if(!stm.writeable)
 				return E_NOTIMPL;
-			written = stm.writeBlock(pv, cb);
+			written = stm.writeBlock(pv, cb).toI32;
 		}
 		catch(DStreamException e)
 		{
@@ -294,7 +294,7 @@ class MemoryIStream: DflComObject, dfl.internal.wincom.IStream
 		seekpos += count;
 		
 		if(pcbRead)
-			*pcbRead = count;
+			*pcbRead = count.toI32;
 		return S_OK;
 	}
 	

--- a/win32/dfl/internal/dlib.d
+++ b/win32/dfl/internal/dlib.d
@@ -32,6 +32,10 @@ alias typeof(""d[]) Ddstring;
 alias typeof(""d.ptr) Ddstringz;
 alias typeof(" "d[0]) Ddchar;
 
+uint toI32(size_t val) @property @safe pure nothrow
+{
+	return cast(uint)val;
+}
 
 version(D_Version2)
 {

--- a/win32/dfl/internal/utf.d
+++ b/win32/dfl/internal/utf.d
@@ -184,11 +184,11 @@ Dstring unicodeToAnsi(Dwstringz unicode, size_t ulen)
 	char[] result;
 	int len;
 	
-	len = WideCharToMultiByte(0, 0, unicode, ulen, null, 0, null, null);
+	len = WideCharToMultiByte(0, 0, unicode, ulen.toI32, null, 0, null, null);
 	assert(len > 0);
 	
 	result = new char[len];
-	len = WideCharToMultiByte(0, 0, unicode, ulen, result.ptr, len, null, null);
+	len = WideCharToMultiByte(0, 0, unicode, ulen.toI32, result.ptr, len, null, null);
 	assert(len == result.length);
 	//return result[0 .. len - 1];
 	return cast(Dstring)result[0 .. len - 1]; // Needed in D2.
@@ -202,7 +202,7 @@ Dwstring ansiToUnicode(Dstringz ansi, size_t len)
 	len++;
 	ws = new wchar[len];
 	
-	len = MultiByteToWideChar(0, 0, ansi, len, ws.ptr, len);
+	len = MultiByteToWideChar(0, 0, ansi, len.toI32, ws.ptr, len.toI32);
 	//assert(len == ws.length);
 	ws = ws[0 .. len - 1]; // Exclude null char at end.
 	
@@ -567,7 +567,7 @@ Dstring getWindowText(HWND hwnd)
 		len++;
 		buf = (new wchar[len]).ptr;
 		
-		len = proc(hwnd, buf, len);
+		len = proc(hwnd, buf, len.toI32);
 		return fromUnicode(buf, len);
 	}
 	else
@@ -581,7 +581,7 @@ Dstring getWindowText(HWND hwnd)
 		len++;
 		buf = (new char[len]).ptr;
 		
-		len = GetWindowTextA(hwnd, buf, len);
+		len = GetWindowTextA(hwnd, buf, len.toI32);
 		return fromAnsi(buf, len);
 	}
 }
@@ -641,7 +641,7 @@ Dstring getModuleFileName(HMODULE hmod)
 		wchar[] s;
 		DWORD len;
 		s = new wchar[MAX_PATH];
-		len = proc(hmod, s.ptr, s.length);
+		len = proc(hmod, s.ptr, s.length.toI32);
 		return fromUnicode(s.ptr, len);
 	}
 	else
@@ -649,7 +649,7 @@ Dstring getModuleFileName(HMODULE hmod)
 		char[] s;
 		DWORD len;
 		s = new char[MAX_PATH];
-		len = GetModuleFileNameA(hmod, s.ptr, s.length);
+		len = GetModuleFileNameA(hmod, s.ptr, s.length.toI32);
 		return fromAnsi(s.ptr, len);
 	}
 }
@@ -746,14 +746,14 @@ Dstring getSelectedText(HWND hwnd)
 			return null;
 		assert(v2 > v1);
 		
-		len = proc(hwnd, WM_GETTEXTLENGTH, 0, 0);
+		len = proc(hwnd, WM_GETTEXTLENGTH, 0, 0).toI32;
 		if(len)
 		{
 			len++;
 			wchar* buf;
 			buf = (new wchar[len]).ptr;
 			
-			len = proc(hwnd, WM_GETTEXT, len, cast(LPARAM)buf);
+			len = proc(hwnd, WM_GETTEXT, len, cast(LPARAM)buf).toI32;
 			if(len)
 			{
 				wchar[] s;
@@ -769,14 +769,14 @@ Dstring getSelectedText(HWND hwnd)
 			return null;
 		assert(v2 > v1);
 		
-		len = SendMessageA(hwnd, WM_GETTEXTLENGTH, 0, 0);
+		len = SendMessageA(hwnd, WM_GETTEXTLENGTH, 0, 0).toI32;
 		if(len)
 		{
 			len++;
 			char* buf;
 			buf = (new char[len]).ptr;
 			
-			len = SendMessageA(hwnd, WM_GETTEXT, len, cast(LPARAM)buf);
+			len = SendMessageA(hwnd, WM_GETTEXT, len, cast(LPARAM)buf).toI32;
 			if(len)
 			{
 				char[] s;
@@ -994,7 +994,7 @@ Dstring getClipboardFormatName(UINT format)
 		wchar[] buf;
 		int len;
 		buf = new wchar[64];
-		len = proc(format, buf.ptr, buf.length);
+		len = proc(format, buf.ptr, buf.length.toI32);
 		if(!len)
 			return null;
 		return fromUnicode(buf.ptr, len);
@@ -1004,7 +1004,7 @@ Dstring getClipboardFormatName(UINT format)
 		char[] buf;
 		int len;
 		buf = new char[64];
-		len = GetClipboardFormatNameA(format, buf.ptr, buf.length);
+		len = GetClipboardFormatNameA(format, buf.ptr, buf.length.toI32);
 		if(!len)
 			return null;
 		return fromAnsi(buf.ptr, len);
@@ -1055,7 +1055,7 @@ int drawTextEx(HDC hdc, Dstring text, LPRECT lprc, UINT dwDTFormat, LPDRAWTEXTPA
 			str = cast(Dwstring)tempStr[0 .. 1]; // Needed in D2.
 		}
 		//return proc(hdc, str.ptr, str.length, lprc, dwDTFormat, lpDTParams);
-		return proc(hdc, cast(wchar*)str.ptr, str.length, lprc, dwDTFormat, lpDTParams); // Needed in D2.
+		return proc(hdc, cast(wchar*)str.ptr, str.length.toI32, lprc, dwDTFormat, lpDTParams); // Needed in D2.
 	}
 	else
 	{
@@ -1075,7 +1075,7 @@ int drawTextEx(HDC hdc, Dstring text, LPRECT lprc, UINT dwDTFormat, LPDRAWTEXTPA
 			str = cast(Dstring)tempStr[0 .. 1]; // Needed in D2.
 		}
 		//return DrawTextExA(hdc, str.ptr, str.length, lprc, dwDTFormat, lpDTParams);
-		return DrawTextExA(hdc, cast(char*)str.ptr, str.length, lprc, dwDTFormat, lpDTParams); // Needed in D2.
+		return DrawTextExA(hdc, cast(char*)str.ptr, str.length.toI32, lprc, dwDTFormat, lpDTParams); // Needed in D2.
 	}
 }
 
@@ -1213,7 +1213,7 @@ Dstring getFullPathName(Dstring fileName)
 			wchar[] wbuf = _wbuf;
 			if(len > _wbuf.sizeof)
 				wbuf = new wchar[len];
-			len = proc(fnw, wbuf.length, wbuf.ptr, null);
+			len = proc(fnw, wbuf.length.toI32, wbuf.ptr, null);
 			assert(len < wbuf.length);
 			return fromUnicode(wbuf.ptr, len);
 		}
@@ -1227,7 +1227,7 @@ Dstring getFullPathName(Dstring fileName)
 			char[] abuf = _abuf;
 			if(len > _abuf.sizeof)
 				abuf = new char[len];
-			len = GetFullPathNameA(fna, abuf.length, abuf.ptr, null);
+			len = GetFullPathNameA(fna, abuf.length.toI32, abuf.ptr, null);
 			assert(len < abuf.length);
 			return fromAnsi(abuf.ptr, len);
 		}
@@ -1299,7 +1299,7 @@ Dstring getSystemDirectory()
 		wchar[] buf;
 		UINT len;
 		buf = new wchar[MAX_PATH];
-		len = proc(buf.ptr, buf.length);
+		len = proc(buf.ptr, buf.length.toI32);
 		if(!len)
 			return null;
 		return fromUnicode(buf.ptr, len);
@@ -1309,7 +1309,7 @@ Dstring getSystemDirectory()
 		char[] buf;
 		UINT len;
 		buf = new char[MAX_PATH];
-		len = GetSystemDirectoryA(buf.ptr, buf.length);
+		len = GetSystemDirectoryA(buf.ptr, buf.length.toI32);
 		if(!len)
 			return null;
 		return fromAnsi(buf.ptr, len);
@@ -1564,7 +1564,7 @@ deprecated BOOL getTextExtentPoint32(HDC hdc, Dstring text, LPSIZE lpSize)
 		
 		Dwstring str;
 		str = toUnicode(text);
-		return proc(hdc, str.ptr, str.length, lpSize);
+		return proc(hdc, str.ptr, str.length.toI32, lpSize);
 	}
 	else
 	{
@@ -1572,7 +1572,7 @@ deprecated BOOL getTextExtentPoint32(HDC hdc, Dstring text, LPSIZE lpSize)
 		// to keep the measurements accurate with DrawTextA.
 		Dstring str;
 		str = unsafeAnsi(text);
-		return GetTextExtentPoint32A(hdc, str.ptr, str.length, lpSize);
+		return GetTextExtentPoint32A(hdc, str.ptr, str.length.toI32, lpSize);
 	}
 }
 
@@ -1607,7 +1607,7 @@ Dstring dragQueryFile(HDROP hDrop, UINT iFile)
 		if(!len)
 			return null;
 		str = new wchar[len + 1];
-		proc(hDrop, iFile, str.ptr, str.length);
+		proc(hDrop, iFile, str.ptr, str.length.toI32);
 		return fromUnicode(str.ptr, len);
 	}
 	else
@@ -1618,7 +1618,7 @@ Dstring dragQueryFile(HDROP hDrop, UINT iFile)
 		if(!len)
 			return null;
 		str = new char[len + 1];
-		DragQueryFileA(hDrop, iFile, str.ptr, str.length);
+		DragQueryFileA(hDrop, iFile, str.ptr, str.length.toI32);
 		return fromAnsi(str.ptr, len);
 	}
 }

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -2483,7 +2483,7 @@ extern(Windows) nothrow:
 	
 	struct CHOOSEFONTW
 	{
-		align(1):
+		//align(1):
 		DWORD lStructSize;
 		HWND hwndOwner;
 		HDC hDC;
@@ -2497,7 +2497,7 @@ extern(Windows) nothrow:
 		HINSTANCE hInstance;
 		LPWSTR lpszStyle;
 		WORD nFontType;
-		WORD ___MISSING_ALIGNMENT__;
+		//WORD ___MISSING_ALIGNMENT__;
 		INT nSizeMin;
 		INT nSizeMax;
 	}
@@ -2507,7 +2507,7 @@ extern(Windows) nothrow:
 	
 	struct CHOOSEFONTA
 	{
-		align(1):
+		//align(1):
 		DWORD lStructSize;
 		HWND hwndOwner;
 		HDC hDC;
@@ -2521,7 +2521,7 @@ extern(Windows) nothrow:
 		HINSTANCE hInstance;
 		LPSTR lpszStyle;
 		WORD nFontType;
-		WORD ___MISSING_ALIGNMENT__;
+		//WORD ___MISSING_ALIGNMENT__;
 		INT nSizeMin;
 		INT nSizeMax;
 	}

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -248,8 +248,8 @@ extern(Windows) nothrow:
 	struct NMMOUSE
 	{
 		NMHDR hdr;
-		DWORD dwItemSpec;
-		DWORD dwItemData;
+		DWORD_PTR dwItemSpec;
+		DWORD_PTR dwItemData;
 		POINT pt;
 		LPARAM dwHitInfo;
 	}
@@ -1892,7 +1892,7 @@ extern(Windows) nothrow:
 	struct NMHDR
 	{ 
 		HWND hwndFrom;
-		UINT idFrom;
+		UINT_PTR idFrom;
 		UINT code;
 	}
 	alias NMHDR* LPNMHDR;
@@ -1904,7 +1904,7 @@ extern(Windows) nothrow:
 		DWORD dwDrawStage;
 		HDC hdc;
 		RECT rc;
-		/+ DWORD_PTR +/ DWORD dwItemSpec;
+		DWORD_PTR dwItemSpec;
 		UINT uItemState;
 		LPARAM lItemlParam;
 	}
@@ -2034,9 +2034,13 @@ extern(Windows) nothrow:
 		int idCommand;
 		BYTE fsState;
 		BYTE fsStyle;
-		BYTE[2] bReserved;
-		DWORD dwData;
-		int iString;
+		version (Win64) {
+			BYTE[6] bReserved;
+		} else {
+			BYTE[2] bReserved;
+		}
+		DWORD_PTR dwData;
+		INT_PTR iString;
 	}
 	alias TBBUTTON* PTBBUTTON, LPTBBUTTON, LPCTBBUTTON;
 	
@@ -2270,7 +2274,7 @@ extern(Windows) nothrow:
 	// Rich edit.
 	struct EDITSTREAM
 	{
-		/+ DWORD_PTR +/ DWORD dwCookie;
+		DWORD_PTR dwCookie;
 		DWORD dwError;
 		EDITSTREAMCALLBACK pfnCallback;
 	}
@@ -2608,7 +2612,7 @@ extern(Windows) nothrow:
 		UINT cbSize;
 		UINT uFlags;
 		HWND hwnd;
-		UINT uId;
+		UINT_PTR uId;
 		RECT rect;
 		HINSTANCE hinst;
 		LPSTR lpszText;
@@ -2679,7 +2683,7 @@ extern(Windows) nothrow:
 		UINT itemID;
 		UINT itemWidth;
 		UINT itemHeight;
-		DWORD itemData;
+		ULONG_PTR itemData;
 	}
 	alias MEASUREITEMSTRUCT* LPMEASUREITEMSTRUCT;
 	

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -1084,28 +1084,38 @@ extern(Windows) nothrow:
 	}
 	
 	
-	version(DFL_D2_AND_ABOVE)
+	version(Win64)
 	{
-		/+ // DMD 2.012: Error: cannot implicitly convert expression (cast(HANDLE)cast(void*)-65536u) of type const(HANDLE) to int
-		const HTREEITEM TVI_ROOT = cast(HTREEITEM)-0x10000;
-		const HTREEITEM TVI_FIRST = cast(HTREEITEM)-0x0FFFF;
-		const HTREEITEM TVI_LAST = cast(HTREEITEM)-0x0FFFE;
-		const HTREEITEM TVI_SORT = cast(HTREEITEM)-0x0FFFD;
-		+/
-		enum: HTREEITEM
-		{
-			TVI_ROOT = cast(HTREEITEM)-0x10000,
-			TVI_FIRST = cast(HTREEITEM)-0x0FFFF,
-			TVI_LAST = cast(HTREEITEM)-0x0FFFE,
-			TVI_SORT = cast(HTREEITEM)-0x0FFFD,
+		enum: HTREEITEM {
+			TVI_ROOT  = cast(HTREEITEM) cast(ULONG_PTR)-0x10000,
+			TVI_FIRST = cast(HTREEITEM) cast(ULONG_PTR)-0xFFFF,
+			TVI_LAST  = cast(HTREEITEM) cast(ULONG_PTR)-0xFFFE,
+			TVI_SORT  = cast(HTREEITEM) cast(ULONG_PTR)-0xFFFD,
 		}
-	}
-	else
-	{
-		const HTREEITEM TVI_ROOT = cast(HTREEITEM)-0x10000;
-		const HTREEITEM TVI_FIRST = cast(HTREEITEM)-0x0FFFF;
-		const HTREEITEM TVI_LAST = cast(HTREEITEM)-0x0FFFE;
-		const HTREEITEM TVI_SORT = cast(HTREEITEM)-0x0FFFD;
+	} else {
+		version(DFL_D2_AND_ABOVE)
+		{
+			/+ // DMD 2.012: Error: cannot implicitly convert expression (cast(HANDLE)cast(void*)-65536u) of type const(HANDLE) to int
+			const HTREEITEM TVI_ROOT = cast(HTREEITEM)-0x10000;
+			const HTREEITEM TVI_FIRST = cast(HTREEITEM)-0x0FFFF;
+			const HTREEITEM TVI_LAST = cast(HTREEITEM)-0x0FFFE;
+			const HTREEITEM TVI_SORT = cast(HTREEITEM)-0x0FFFD;
+			+/
+			enum: HTREEITEM
+			{
+				TVI_ROOT = cast(HTREEITEM)-0x10000,
+				TVI_FIRST = cast(HTREEITEM)-0x0FFFF,
+				TVI_LAST = cast(HTREEITEM)-0x0FFFE,
+				TVI_SORT = cast(HTREEITEM)-0x0FFFD,
+			}
+		}
+		else
+		{
+			const HTREEITEM TVI_ROOT = cast(HTREEITEM)-0x10000;
+			const HTREEITEM TVI_FIRST = cast(HTREEITEM)-0x0FFFF;
+			const HTREEITEM TVI_LAST = cast(HTREEITEM)-0x0FFFE;
+			const HTREEITEM TVI_SORT = cast(HTREEITEM)-0x0FFFD;
+		}
 	}
 	
 	

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -1751,7 +1751,7 @@ extern(Windows) nothrow:
 	
 	
 	// Rich edit.
-	alias DWORD function(/+ DWORD_PTR +/ DWORD dwCookie, LPBYTE pbBuff, LONG cb, LONG* pcb) EDITSTREAMCALLBACK;
+	alias DWORD function(DWORD_PTR dwCookie, LPBYTE pbBuff, LONG cb, LONG* pcb) EDITSTREAMCALLBACK;
 	
 	
 	alias DWORD LCID;
@@ -2400,10 +2400,10 @@ extern(Windows) nothrow:
 	alias OPENFILENAMEW* LPOPENFILENAMEW;
 	
 	
-	alias UINT function(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam) LPCCHOOKPROC;
+	alias UINT_PTR function(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam) LPCCHOOKPROC;
 	
 	
-	alias UINT function(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam) LPCFHOOKPROC;
+	alias UINT_PTR function(HWND hdlg, UINT uiMsg, WPARAM wParam, LPARAM lParam) LPCFHOOKPROC;
 	
 	
 	alias BOOL function(HDC hdc, LPARAM lpData, int cchData) GRAYSTRINGPROC;

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -2886,8 +2886,8 @@ extern(Windows) nothrow:
 	BOOL IsDialogMessageW(HWND hDlg, LPMSG lpMsg);
 	HBRUSH GetSysColorBrush(int nIndex);
 	BOOL PostMessageA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
-	UINT SetTimer(HWND hWnd, UINT nIDEvent, UINT uElapse, TIMERPROC lpTimerFunc);
-	BOOL KillTimer(HWND hWnd, UINT uIDEvent);
+	UINT_PTR SetTimer(HWND hWnd, UINT_PTR nIDEvent, UINT uElapse, TIMERPROC lpTimerFunc);
+	BOOL KillTimer(HWND hWnd, UINT_PTR uIDEvent);
 	LPSTR GetCommandLineA();
 	LPWSTR GetCommandLineW();
 	BOOL SetCurrentDirectoryW(LPCWSTR lpPathName);

--- a/win32/dfl/internal/winapi.d
+++ b/win32/dfl/internal/winapi.d
@@ -2823,10 +2823,21 @@ extern(Windows) nothrow:
 	HWND CreateWindowExW(DWORD dwExStyle, LPCWSTR lpClassName, LPCWSTR lpWindowName, DWORD dwStyle, int x, int y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam);
 	LRESULT SendMessageW(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 	int MessageBoxW(HWND hWnd, LPCWSTR lpText, LPCWSTR lpCaption, UINT uType);
-	DWORD SetClassLongA(HWND hWnd, int nIndex, LONG dwNewLong);
-	DWORD GetClassLongA(HWND hWnd, int nIndex);
-	LONG SetWindowLongA(HWND hWnd, int nIndex, LONG dwNewLong);
-	LONG GetWindowLongA(HWND hWnd, int nIndex);
+	DWORD SetClassLongA(HWND hWnd, int nIndex, LONG dwNewLong); // deprecated
+	DWORD GetClassLongA(HWND hWnd, int nIndex); // deprecated
+	LONG SetWindowLongA(HWND hWnd, int nIndex, LONG dwNewLong); // deprecated
+	LONG GetWindowLongA(HWND hWnd, int nIndex); // deprecated
+	version (Win64) {
+		ULONG_PTR SetClassLongPtrA(HWND hWnd, int nIndex, LONG_PTR dwNewLong);
+		ULONG_PTR GetClassLongPtrA(HWND hWnd, int nIndex);
+		LONG_PTR SetWindowLongPtrA(HWND hWnd, int nIndex, LONG_PTR dwNewLong);
+		LONG_PTR GetWindowLongPtrA(HWND hWnd, int nIndex);
+	} else {
+		alias SetClassLongPtrA = SetClassLongA;
+		alias GetClassLongPtrA = GetClassLongA;
+		alias SetWindowLongPtrA = SetWindowLongA;
+		alias GetWindowLongPtrA = GetWindowLongA;
+	}
 	DWORD GetSysColor(int nIndex);
 	BOOL EnableWindow(HWND hWnd, BOOL bEnable);
 	BOOL IsWindowEnabled(HWND hWnd);

--- a/win32/dfl/listbox.d
+++ b/win32/dfl/listbox.d
@@ -895,7 +895,7 @@ class ListBox: ListControl // docmain
 	///
 	final int getItemHeight(int idx)
 	{
-		int result = prevwproc(LB_GETITEMHEIGHT, idx, 0);
+		int result = prevwproc(LB_GETITEMHEIGHT, idx, 0).toI32;
 		if(LB_ERR == result)
 			throw new DflException("Unable to obtain item height");
 		return result;

--- a/win32/dfl/listbox.d
+++ b/win32/dfl/listbox.d
@@ -1168,7 +1168,7 @@ class ListBox: ListControl // docmain
 		
 		// Set the Ctrl ID to the HWND so that it is unique
 		// and WM_MEASUREITEM will work properly.
-		SetWindowLongA(hwnd, GWL_ID, cast(LONG)hwnd);
+		SetWindowLongPtrA(hwnd, GWL_ID, cast(LONG_PTR)hwnd);
 		
 		if(hextent != 0)
 			prevwproc(LB_SETHORIZONTALEXTENT, hextent, 0);

--- a/win32/dfl/listbox.d
+++ b/win32/dfl/listbox.d
@@ -129,7 +129,7 @@ class ListBox: ListControl // docmain
 			
 			if(lbox.isMultSel())
 			{
-				return lbox.prevwproc(LB_GETSELCOUNT, 0, 0);
+				return lbox.prevwproc(LB_GETSELCOUNT, 0, 0).toI32;
 			}
 			else
 			{
@@ -225,7 +225,7 @@ class ListBox: ListControl // docmain
 			
 			if(lbox.isMultSel())
 			{
-				return lbox.prevwproc(LB_GETSELCOUNT, 0, 0);
+				return lbox.prevwproc(LB_GETSELCOUNT, 0, 0).toI32;
 			}
 			else
 			{
@@ -787,7 +787,7 @@ class ListBox: ListControl // docmain
 	final @property int topIndex() // getter
 	{
 		if(isHandleCreated)
-			return prevwproc(LB_GETTOPINDEX, 0, 0);
+			return prevwproc(LB_GETTOPINDEX, 0, 0).toI32;
 		return 0;
 	}
 	
@@ -848,9 +848,9 @@ class ListBox: ListControl // docmain
 		if(created)
 		{
 			if(dfl.internal.utf.useUnicode)
-				result = prevwproc(LB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str));
+				result = prevwproc(LB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str)).toI32;
 			else
-				result = prevwproc(LB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str));
+				result = prevwproc(LB_FINDSTRING, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str)).toI32;
 			if(result == LB_ERR) // Redundant.
 				result = NO_MATCHES;
 		}
@@ -875,9 +875,9 @@ class ListBox: ListControl // docmain
 		if(created)
 		{
 			if(dfl.internal.utf.useUnicode)
-				result = prevwproc(LB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str));
+				result = prevwproc(LB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.toUnicodez(str)).toI32;
 			else
-				result = prevwproc(LB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str));
+				result = prevwproc(LB_FINDSTRINGEXACT, startIndex, cast(LPARAM)dfl.internal.utf.unsafeAnsiz(str)).toI32;
 			if(result == LB_ERR) // Redundant.
 				result = NO_MATCHES;
 		}
@@ -935,7 +935,7 @@ class ListBox: ListControl // docmain
 		
 		if(created)
 		{
-			result = prevwproc(LB_ITEMFROMPOINT, 0, MAKELPARAM(x, y));
+			result = prevwproc(LB_ITEMFROMPOINT, 0, MAKELPARAM(x, y)).toI32;
 			if(!HIWORD(result)) // In client area
 			{
 				//result = LOWORD(result); // High word already 0.
@@ -1073,7 +1073,7 @@ class ListBox: ListControl // docmain
 		
 		LRESULT insert2(WPARAM idx, Dstring val)
 		{
-			insert(idx, val);
+			insert(idx.toI32, val);
 			return idx;
 		}
 		
@@ -1083,7 +1083,7 @@ class ListBox: ListControl // docmain
 			int i;
 			if(lbox.sorted)
 			{
-				for(i = 0; i != _items.length; i++)
+				for(i = 0; i != _items.length.toI32; i++)
 				{
 					if(val < _items[i])
 						break;
@@ -1091,7 +1091,7 @@ class ListBox: ListControl // docmain
 			}
 			else
 			{
-				i = _items.length;
+				i = _items.length.toI32;
 			}
 			
 			insert(i, val);
@@ -1380,7 +1380,7 @@ class ListBox: ListControl // docmain
 				return;
 			
 			case LB_DELETESTRING:
-				icollection.removeAt(msg.wParam);
+				icollection.removeAt(msg.wParam.toI32);
 				msg.result = icollection.length;
 				return;
 			

--- a/win32/dfl/listview.d
+++ b/win32/dfl/listview.d
@@ -719,11 +719,11 @@ class ListView: ControlSuperClass // docmain
 			switch(lv.sorting)
 			{
 				case SortOrder.NONE: // Add to end.
-					ii = _items.length;
+					ii = _items.length.toI32;
 					break;
 				
 				case SortOrder.ASCENDING: // Insertion sort.
-					for(ii = 0; ii != _items.length; ii++)
+					for(ii = 0; ii != _items.length.toI32; ii++)
 					{
 						assert(lv._sortproc);
 						//if(item < _items[ii])
@@ -733,7 +733,7 @@ class ListView: ControlSuperClass // docmain
 					break;
 				
 				case SortOrder.DESCENDING: // Insertion sort.
-					for(ii = 0; ii != _items.length; ii++)
+					for(ii = 0; ii != _items.length.toI32; ii++)
 					{
 						assert(lv._sortproc);
 						//if(item >= _items[ii])
@@ -842,7 +842,7 @@ class ListView: ControlSuperClass // docmain
 			int i;
 			if(created)
 			{
-				i = lv._ins(idx, val);
+				i = lv._ins(idx.toI32, val);
 				assert(-1 != i);
 			}
 		}
@@ -938,7 +938,7 @@ class ListView: ControlSuperClass // docmain
 			int i;
 			if(created)
 			{
-				i = lv._ins(idx, val);
+				i = lv._ins(idx.toI32, val);
 				assert(-1 != i);
 			}
 		}
@@ -1203,9 +1203,9 @@ class ListView: ControlSuperClass // docmain
 			int result = 0;
 			foreach(ref size_t i, ref ListViewItem lvitem; lview.items)
 			{
-				if(lvitem._getcheckstate(i))
+				if(lvitem._getcheckstate(i.toI32))
 				{
-					int dgidx = i; // Prevent ref.
+					int dgidx = i.toI32; // Prevent ref.
 					result = dg(dgidx);
 					if(result)
 						break;
@@ -1775,7 +1775,7 @@ class ListView: ControlSuperClass // docmain
 					SendMessageA(handle, LVM_DELETEALLITEMS, 0, 0); // Note: this sends LVN_DELETEALLITEMS.
 					foreach(idx, lvi; sitems)
 					{
-						_ins(idx, lvi);
+						_ins(idx.toI32, lvi);
 					}
 					endUpdate();
 				}
@@ -2575,7 +2575,7 @@ class ListView: ControlSuperClass // docmain
 	
 	// If -subItemIndex- is 0 it's an item not a sub item.
 	// Returns the insertion index or -1 on failure.
-	package final LRESULT _ins(int index, LPARAM lparam, Dstring itemText, int subItemIndex, int imageIndex = -1)
+	package final int _ins(int index, LPARAM lparam, Dstring itemText, int subItemIndex, int imageIndex = -1)
 	in
 	{
 		assert(created);
@@ -2605,36 +2605,36 @@ class ListView: ControlSuperClass // docmain
 		//lvi.pszText = toStringz(itemText);
 		lvi.pszText = LPSTR_TEXTCALLBACKA;
 		lvi.lParam = lparam;
-		return prevwproc(LVM_INSERTITEMA, 0, cast(LPARAM)&lvi);
+		return prevwproc(LVM_INSERTITEMA, 0, cast(LPARAM)&lvi).toI32;
 	}
 	
 	
-	package final LRESULT _ins(int index, ListViewItem item)
+	package final int _ins(int index, ListViewItem item)
 	{
 		//return _ins(index, cast(LPARAM)cast(void*)item, item.text, 0);
 		version(DFL_NO_IMAGELIST)
 		{
-			return _ins(index, cast(LPARAM)cast(void*)item, item.text, 0, -1);
+			return _ins(index, cast(LPARAM)cast(void*)item, item.text, 0, -1).toI32;
 		}
 		else
 		{
-			return _ins(index, cast(LPARAM)cast(void*)item, item.text, 0, item._imgidx);
+			return _ins(index, cast(LPARAM)cast(void*)item, item.text, 0, item._imgidx).toI32;
 		}
 	}
 	
 	
-	package final LRESULT _ins(int index, ListViewSubItem subItem, int subItemIndex)
+	package final int _ins(int index, ListViewSubItem subItem, int subItemIndex)
 	in
 	{
 		assert(subItemIndex > 0);
 	}
 	body
 	{
-		return _ins(index, cast(LPARAM)cast(void*)subItem, subItem.text, subItemIndex);
+		return _ins(index, cast(LPARAM)cast(void*)subItem, subItem.text, subItemIndex).toI32;
 	}
 	
 	
-	package final LRESULT _ins(int index, ColumnHeader header)
+	package final int _ins(int index, ColumnHeader header)
 	{
 		// TODO: column inserted at index 0 can only be left aligned, so will need to
 		// insert a dummy column to change the alignment, then delete the dummy column.
@@ -2660,12 +2660,12 @@ class ListView: ControlSuperClass // docmain
 		if(dfl.internal.utf.useUnicode)
 		{
 			lvc.lvcw.pszText = cast(typeof(lvc.lvcw.pszText))dfl.internal.utf.toUnicodez(header.text);
-			return prevwproc(LVM_INSERTCOLUMNW, cast(WPARAM)index, cast(LPARAM)&lvc.lvcw);
+			return prevwproc(LVM_INSERTCOLUMNW, cast(WPARAM)index, cast(LPARAM)&lvc.lvcw).toI32;
 		}
 		else
 		{
 			lvc.lvca.pszText = cast(typeof(lvc.lvca.pszText))dfl.internal.utf.toAnsiz(header.text);
-			return prevwproc(LVM_INSERTCOLUMNA, cast(WPARAM)index, cast(LPARAM)&lvc.lvca);
+			return prevwproc(LVM_INSERTCOLUMNA, cast(WPARAM)index, cast(LPARAM)&lvc.lvca).toI32;
 		}
 	}
 	

--- a/win32/dfl/listview.d
+++ b/win32/dfl/listview.d
@@ -2301,7 +2301,7 @@ class ListView: ControlSuperClass // docmain
 								{
 									if(lvdi.item.mask & LVIF_TEXT)
 									{
-										if(lvdi.item.iSubItem <= item.subItems.length)
+										if(lvdi.item.iSubItem <= item.subItems.length.toI32)
 											lvdi.item.pszText = cast(typeof(lvdi.item.pszText))item.subItems[lvdi.item.iSubItem - 1].calltxt.ansi;
 									}
 								}
@@ -2337,7 +2337,7 @@ class ListView: ControlSuperClass // docmain
 								{
 									if(lvdi.item.mask & LVIF_TEXT)
 									{
-										if(lvdi.item.iSubItem <= item.subItems.length)
+										if(lvdi.item.iSubItem <= item.subItems.length.toI32)
 											lvdi.item.pszText = cast(typeof(lvdi.item.pszText))item.subItems[lvdi.item.iSubItem - 1].calltxt.unicode;
 									}
 								}

--- a/win32/dfl/listview.d
+++ b/win32/dfl/listview.d
@@ -242,8 +242,8 @@ class ListViewItem: DObject
 		if(lview && lview.created)
 		{
 			LV_ITEMA li;
-			li.stateMask = LVIS_STATEIMAGEMASK;
-			li.state = cast(LPARAM)(bchecked ? 2 : 1) << 12;
+			li.stateMask = LVIS_STATEIMAGEMASK; // Bits 12 through 15 of the member state
+			li.state = cast(UINT)(bchecked ? 2 : 1) << 12;
 			lview.prevwproc(LVM_SETITEMSTATE, cast(WPARAM)thisindex, cast(LPARAM)&li);
 		}
 	}

--- a/win32/dfl/menu.d
+++ b/win32/dfl/menu.d
@@ -145,7 +145,7 @@ else
 			mparent = newParent;
 			
 			if(cast(size_t)mindex > mparent.menuItems.length)
-				mindex = mparent.menuItems.length;
+				mindex = mparent.menuItems.length.toI32;
 			
 			_setParent();
 		}
@@ -779,7 +779,7 @@ else
 			{
 				if(!Menu._compat092)
 				{
-					mi.mindex = length;
+					mi.mindex = length.toI32;
 				}
 				
 				/+
@@ -829,7 +829,7 @@ else
 			
 			void _added(size_t idx, MenuItem val)
 			{
-				val.mindex = idx;
+				val.mindex = idx.toI32;
 				val._setParent(_owner);
 				_additem(val);
 			}

--- a/win32/dfl/menu.d
+++ b/win32/dfl/menu.d
@@ -802,7 +802,7 @@ else
 				
 				foreach(MenuItem it; items)
 				{
-					insert(length, it);
+					insert(length.toI32, it);
 				}
 			}
 			
@@ -813,7 +813,7 @@ else
 				
 				foreach(Dstring it; items)
 				{
-					insert(length, it);
+					insert(length.toI32, it);
 				}
 			}
 			
@@ -845,8 +845,8 @@ else
 					val._unsetParent();
 					//RemoveMenu(_owner.handle, val._menuID, MF_BYCOMMAND);
 					//_owner._remove(val._menuID, MF_BYCOMMAND);
-					_owner._remove(idx, MF_BYPOSITION);
-					_delitem(idx);
+					_owner._remove(idx.toI32, MF_BYPOSITION);
+					_delitem(idx.toI32);
 				}
 			}
 			
@@ -864,7 +864,7 @@ else
 		// Extra.
 		deprecated final void opCatAssign(MenuItem mi)
 		{
-			menuItems.insert(menuItems.length, mi);
+			menuItems.insert(menuItems.length.toI32, mi);
 		}
 		
 		

--- a/win32/dfl/notifyicon.d
+++ b/win32/dfl/notifyicon.d
@@ -73,7 +73,7 @@ class NotifyIcon // docmain
 		txt = unsafeAnsi(txt); // ...
 		nid.szTip[txt.length] = 0;
 		nid.szTip[0 .. txt.length] = txt[];
-		tipLen = txt.length;
+		tipLen = txt.length.toI32;
 		
 		if(visible)
 		{
@@ -192,7 +192,7 @@ class NotifyIcon // docmain
 		HWND hwnd;
 		
 		hwnd = win.handle;
-		style = GetWindowLongPtrA(hwnd, GWL_STYLE);
+		style = GetWindowLongPtrA(hwnd, GWL_STYLE).toI32;
 		
 		if(style & WS_VISIBLE)
 		{
@@ -220,7 +220,7 @@ class NotifyIcon // docmain
 		HWND hwnd;
 		
 		hwnd = win.handle;
-		style = GetWindowLongPtrA(hwnd, GWL_STYLE);
+		style = GetWindowLongPtrA(hwnd, GWL_STYLE).toI32;
 		
 		if(!(style & WS_VISIBLE))
 		{

--- a/win32/dfl/notifyicon.d
+++ b/win32/dfl/notifyicon.d
@@ -192,7 +192,7 @@ class NotifyIcon // docmain
 		HWND hwnd;
 		
 		hwnd = win.handle;
-		style = GetWindowLongA(hwnd, GWL_STYLE);
+		style = GetWindowLongPtrA(hwnd, GWL_STYLE);
 		
 		if(style & WS_VISIBLE)
 		{
@@ -220,7 +220,7 @@ class NotifyIcon // docmain
 		HWND hwnd;
 		
 		hwnd = win.handle;
-		style = GetWindowLongA(hwnd, GWL_STYLE);
+		style = GetWindowLongPtrA(hwnd, GWL_STYLE);
 		
 		if(!(style & WS_VISIBLE))
 		{

--- a/win32/dfl/registry.d
+++ b/win32/dfl/registry.d
@@ -11,7 +11,7 @@ private import dfl.internal.dlib;
 
 private import dfl.internal.winapi, dfl.base, dfl.internal.utf;
 
-
+version (Win64) { /* not supported at this point */ } else:
 class DflRegistryException: DflException // package
 {
 	this(Dstring msg, int errorCode = 0)

--- a/win32/dfl/richtextbox.d
+++ b/win32/dfl/richtextbox.d
@@ -739,7 +739,7 @@ class RichTextBox: TextBoxBase // docmain
 			return -1; // ...
 		if(charIndex < 0)
 			return -1;
-		return SendMessageA(hwnd, EM_EXLINEFROMCHAR, 0, charIndex);
+		return SendMessageA(hwnd, EM_EXLINEFROMCHAR, 0, charIndex).toI32;
 	}
 	
 	
@@ -944,7 +944,7 @@ class RichTextBox: TextBoxBase // docmain
 		tr.lpstrText = s.ptr;
 		
 		//max = SendMessageA(handle, EM_GETTEXTRANGE, 0, cast(LPARAM)&tr);
-		max = dfl.internal.utf.sendMessage(handle, EM_GETTEXTRANGE, 0, cast(LPARAM)&tr);
+		max = dfl.internal.utf.sendMessage(handle, EM_GETTEXTRANGE, 0, cast(LPARAM)&tr).toI32;
 		Dstring result;
 		if(dfl.internal.utf.useUnicode)
 			result = fromUnicode(cast(wchar*)s.ptr, max);
@@ -1032,7 +1032,7 @@ private extern(Windows) DWORD _streamingInStr(DWORD_PTR dwCookie, LPBYTE pbBuff,
 	else if(cb >= si.str.length)
 	{
 		pbBuff[0 .. si.str.length] = (cast(BYTE[])si.str)[];
-		*pcb = si.str.length;
+		*pcb = si.str.length.toI32;
 		si.str = null;
 	}
 	else

--- a/win32/dfl/richtextbox.d
+++ b/win32/dfl/richtextbox.d
@@ -1019,7 +1019,7 @@ class RichTextBox: TextBoxBase // docmain
 }
 
 
-private extern(Windows) DWORD _streamingInStr(DWORD dwCookie, LPBYTE pbBuff, LONG cb, LONG* pcb) nothrow
+private extern(Windows) DWORD _streamingInStr(DWORD_PTR dwCookie, LPBYTE pbBuff, LONG cb, LONG* pcb) nothrow
 {
 	RichTextBox._StreamStr* si;
 	si = cast(typeof(si))dwCookie;
@@ -1046,7 +1046,7 @@ private extern(Windows) DWORD _streamingInStr(DWORD dwCookie, LPBYTE pbBuff, LON
 }
 
 
-private extern(Windows) DWORD _streamingOutStr(DWORD dwCookie, LPBYTE pbBuff, LONG cb, LONG* pcb) nothrow
+private extern(Windows) DWORD _streamingOutStr(DWORD_PTR dwCookie, LPBYTE pbBuff, LONG cb, LONG* pcb) nothrow
 {
 	RichTextBox._StreamStr* so;
 	so = cast(typeof(so))dwCookie;

--- a/win32/dfl/richtextbox.d
+++ b/win32/dfl/richtextbox.d
@@ -793,7 +793,7 @@ class RichTextBox: TextBoxBase // docmain
 		EDITSTREAM es;
 		
 		si.str = str;
-		es.dwCookie = cast(DWORD)&si;
+		es.dwCookie = cast(DWORD_PTR)&si;
 		es.pfnCallback = &_streamingInStr;
 		
 		//if(SendMessageA(handle, EM_STREAMIN, cast(WPARAM)fmt, cast(LPARAM)&es) != str.length)
@@ -814,7 +814,7 @@ class RichTextBox: TextBoxBase // docmain
 		EDITSTREAM es;
 		
 		so.str = null;
-		es.dwCookie = cast(DWORD)&so;
+		es.dwCookie = cast(DWORD_PTR)&so;
 		es.pfnCallback = &_streamingOutStr;
 		
 		SendMessageA(handle, EM_STREAMOUT, cast(WPARAM)fmt, cast(LPARAM)&es);

--- a/win32/dfl/socket.d
+++ b/win32/dfl/socket.d
@@ -4,7 +4,7 @@
 
 ///
 module dfl.socket;
-
+version (Win64) { /* not supported at this point */ } else:
 
 version(WINE)
 {

--- a/win32/dfl/tabcontrol.d
+++ b/win32/dfl/tabcontrol.d
@@ -775,7 +775,7 @@ class TabControl: TabControlBase // docmain
 	///
 	final @property int tabCount() // getter
 	{
-		return tchildren._pages.length;
+		return tchildren._pages.length.toI32;
 	}
 	
 	

--- a/win32/dfl/textbox.d
+++ b/win32/dfl/textbox.d
@@ -386,7 +386,7 @@ abstract class TextBoxBase: ControlSuperClass // docmain
 		if(!(ctrlStyle & ControlStyles.CACHE_TEXT) && created())
 			//return cast(uint)SendMessageA(handle, WM_GETTEXTLENGTH, 0, 0);
 			return cast(uint)dfl.internal.utf.sendMessage(handle, WM_GETTEXTLENGTH, 0, 0);
-		return wtext.length;
+		return wtext.length.toI32;
 	}
 	
 	
@@ -824,7 +824,7 @@ abstract class TextBoxBase: ControlSuperClass // docmain
 			return -1; // ...
 		if(line < 0)
 			return -1;
-		return SendMessageA(hwnd, EM_LINEINDEX, line, 0);
+		return SendMessageA(hwnd, EM_LINEINDEX, line, 0).toI32;
 	}
 	
 	/// ditto
@@ -832,7 +832,7 @@ abstract class TextBoxBase: ControlSuperClass // docmain
 	{
 		if(!isHandleCreated)
 			return -1; // ...
-		return SendMessageA(hwnd, EM_LINEINDEX, -1, 0);
+		return SendMessageA(hwnd, EM_LINEINDEX, -1, 0).toI32;
 	}
 	
 	
@@ -843,7 +843,7 @@ abstract class TextBoxBase: ControlSuperClass // docmain
 			return -1; // ...
 		if(charIndex < 0)
 			return -1;
-		return SendMessageA(hwnd, EM_LINEFROMCHAR, charIndex, 0);
+		return SendMessageA(hwnd, EM_LINEFROMCHAR, charIndex, 0).toI32;
 	}
 	
 	

--- a/win32/dfl/timer.d
+++ b/win32/dfl/timer.d
@@ -36,7 +36,7 @@ class Timer // docmain
 	
 	
 	///
-	final @property void interval(size_t timeout) // setter
+	final @property void interval(uint timeout) // setter
 	{
 		if(!timeout)
 			throw new DflException("Invalid timer interval");
@@ -56,7 +56,7 @@ class Timer // docmain
 	}
 	
 	/// ditto
-	final @property size_t interval() // getter
+	final @property uint interval() // getter
 	{
 		return _timeout;
 	}
@@ -147,7 +147,7 @@ class Timer // docmain
 	
 	private:
 	DWORD _timeout = 100;
-	UINT timerId = 0;
+	UINT_PTR timerId = 0;
 	void delegate(Timer) _dg;
 	
 	
@@ -161,10 +161,10 @@ class Timer // docmain
 
 private:
 
-Timer[UINT] allTimers;
+Timer[UINT_PTR] allTimers;
 
 
-extern(Windows) void timerProc(HWND hwnd, UINT uMsg, UINT idEvent, DWORD dwTime) nothrow
+extern(Windows) void timerProc(HWND hwnd, UINT uMsg, UINT_PTR idEvent, DWORD dwTime) nothrow
 {
 	try
 	{

--- a/win32/dfl/toolbar.d
+++ b/win32/dfl/toolbar.d
@@ -568,7 +568,7 @@ class ToolBar: ControlSuperClass // docmain
 	{
 		super.onHandleCreated(ea);
 		
-		static assert(TBBUTTON.sizeof == 20);
+		//static assert(TBBUTTON.sizeof == 20);
 		prevwproc(TB_BUTTONSTRUCTSIZE, TBBUTTON.sizeof, 0);
 		
 		//prevwproc(TB_SETPADDING, 0, MAKELPARAM(0, 0));

--- a/win32/dfl/tooltip.d
+++ b/win32/dfl/tooltip.d
@@ -121,7 +121,7 @@ class ToolTip // docmain
 	final @property void showAlways(bool byes) // setter
 	{
 		LONG wl;
-		wl = GetWindowLongA(hwtt, GWL_STYLE);
+		wl = GetWindowLongPtrA(hwtt, GWL_STYLE);
 		if(byes)
 		{
 			if(wl & TTS_ALWAYSTIP)
@@ -134,13 +134,13 @@ class ToolTip // docmain
 				return;
 			wl &= ~TTS_ALWAYSTIP;
 		}
-		SetWindowLongA(hwtt, GWL_STYLE, wl);
+		SetWindowLongPtrA(hwtt, GWL_STYLE, wl);
 	}
 	
 	/// ditto
 	final @property bool showAlways() // getter
 	{
-		return (GetWindowLongA(hwtt, GWL_STYLE) & TTS_ALWAYSTIP) != 0;
+		return (GetWindowLongPtrA(hwtt, GWL_STYLE) & TTS_ALWAYSTIP) != 0;
 	}
 	
 	

--- a/win32/dfl/tooltip.d
+++ b/win32/dfl/tooltip.d
@@ -121,7 +121,7 @@ class ToolTip // docmain
 	final @property void showAlways(bool byes) // setter
 	{
 		LONG wl;
-		wl = GetWindowLongPtrA(hwtt, GWL_STYLE);
+		wl = GetWindowLongPtrA(hwtt, GWL_STYLE).toI32;
 		if(byes)
 		{
 			if(wl & TTS_ALWAYSTIP)

--- a/win32/dfl/treeview.d
+++ b/win32/dfl/treeview.d
@@ -714,7 +714,7 @@ class TreeNodeCollection
 		}
 		else
 		{
-			i = _nodes.length;
+			i = _nodes.length.toI32;
 		}
 		
 		insert(i, node);


### PR DESCRIPTION
# Win64 support

Note: This depends on #49 COFF Format Support.
## Goal
1. Minimal patches.
2. No breaking change to win32 programs.
## Limitations
1. Win64-support by DMD requires MS Visual Studio and Windows SDK.
2. dfl.socket and dfl.registry are NOT supported ths time. ( ignored by "version (Win64) {...}" )
## Fix compile error

Fix Dozens of size_t conversion error.

Add toI32 helper function instead of type cast.

Especially, collection helpers are rather complicated.
## Fix runtime error
### Update WIn32 APIs
1. SetWindowLong family.
   SetWindowLong -> SetWindowLongPtr, and so on.
2. Common dialogs: structures and callbacks.
   UINT -> UINT_PTR, and so on.
3. Windows timer functions: callbacks.
### Fix application manifest

embedded in dfl/application.d.
## Split off Toolchain update

See #49
